### PR TITLE
Add: LucideとMUIを導入しました

### DIFF
--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -12,3 +12,16 @@ a {
 * {
   box-sizing: border-box;
 }
+
+
+:root {
+  /* Colors */
+  --main-bg-color: #FFFFFF;
+  --primary-color: #3F7D58; 
+  --secondary-color: #5EBC84;
+  --text-black: #1E1E1E;
+
+  /* Font sizes */
+  --title-size: 2rem;
+  --subtitle-size:1.2rem;
+}

--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -9,6 +9,12 @@ a {
   text-decoration: none;
 }
 
+h1, h2{
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+
 * {
   box-sizing: border-box;
 }
@@ -17,11 +23,18 @@ a {
 :root {
   /* Colors */
   --main-bg-color: #FFFFFF;
-  --primary-color: #3F7D58; 
+  --primary-color: #3F7D58;
   --secondary-color: #5EBC84;
   --text-black: #1E1E1E;
 
   /* Font sizes */
   --title-size: 2rem;
   --subtitle-size:1.2rem;
+}
+
+.lucide{
+  stroke-width: 1.2px;
+  height: 20px;
+  width: 20px;
+  color: var(--text-black);
 }

--- a/miniApp/frontend/components/atoms/ratingBar/RatingBar.module.css
+++ b/miniApp/frontend/components/atoms/ratingBar/RatingBar.module.css
@@ -1,0 +1,40 @@
+.content{
+    color: var(--primary-color);
+    font-weight: 500;
+}
+
+.priceRange {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+}
+
+.title{
+  font-weight: bold;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border: 1px solid var(--primary-color);
+  border-radius: 9999px;
+}
+
+.priceDots {
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border: 1px solid var(--primary-color);
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid var(--primary-color);
+}
+
+.dot.active {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}

--- a/miniApp/frontend/components/atoms/ratingBar/RatingBar.tsx
+++ b/miniApp/frontend/components/atoms/ratingBar/RatingBar.tsx
@@ -1,0 +1,34 @@
+import styles from "./RatingBar.module.css"
+import { FunctionComponent } from "react"
+
+type Props = {
+    title: string;
+    leftLabel: string;
+    rightLabel: string;
+    rate: number; // 評価値は0オリジンです
+}
+
+const MAX_LEVELS = 5;
+
+export const RatingBar: FunctionComponent<Props> = ({ title, leftLabel, rightLabel, rate}: Props) => {
+    return (
+        <div className={styles.content}>
+            <div className={styles.priceRange}>
+            <span className={styles.title}>{title}</span>
+            <div className={styles.priceDots}>
+                <span>{leftLabel}</span>
+                    {Array.from({ length: MAX_LEVELS }, (_,i) => {
+                        const level = i;
+                        const isActive = rate === level;
+
+                        return(
+                            <span key={level} className={`${styles.dot} ${isActive ? styles.active : ""}`}></span>
+                        )
+                    })}
+
+                <span>{rightLabel}</span>
+            </div>
+          </div>
+        </div>
+    )
+}

--- a/miniApp/frontend/package-lock.json
+++ b/miniApp/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@line/liff": "2.27.3",
+        "lucide-react": "^0.563.0",
         "next": "16.1.4",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -5733,6 +5734,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.563.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/miniApp/frontend/package.json
+++ b/miniApp/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@line/liff": "2.27.3",
+    "lucide-react": "^0.563.0",
     "next": "16.1.4",
     "react": "19.2.3",
     "react-dom": "19.2.3"


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
LucideとMUIを導入しました🎉 
## 変更の理由・背景
- アイコンをわざわざ持ってくるのが面倒だったり、UIコンポーネントを作成する時間を短縮して、プロトタイプ完成までの時間の効率化を図りたかったため。

## 変更内容
- Lucideパッケージを導入しました。
- MUI(Material UI)パッケージを導入しました。

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点

> [!NOTE]
> 新しいパッケージを追加したため、Pull時に`npm ci`をしてください！

## その他
- Lucideで提供されているアイコンは[Lucide/Icons](https://lucide.dev/icons/)に書いてあります！
- MUIで提供されているコンポーネントは[Material UI Components](https://mui.com/material-ui/all-components/)に書いてあります！