### PR TITLE
スポットカードのスタイル調整

### DIFF
--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -5,11 +5,20 @@
     width: 100%;
     max-width: 600px;
     background: #f4f4f4;
-    border-radius: clamp(16px, 2vw, 24px);
+    border: 1.2px solid #c3c3c3;
+    border-radius: 24px;
     overflow: hidden;
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
     display: flex;
     flex-direction: column;
+
+    /* global.cssに統合 */
+    font-family: 
+        "Hiragino Kaku Gothic ProN",
+        "Hiragino Sans",
+        "Yu Gothic",
+        "Meiryo",
+        "Noto Sans JP",;
 }
 
 
@@ -19,33 +28,35 @@
 .cardHeader {
     display: flex;
     align-items: center;
-    padding: clamp(12px, 2vw, 20px);
+    padding-right: 8px;
     gap: clamp(8px, 1.5vw, 16px);
 }
 
 .title {
-    font-size: clamp(20px, 3.2vw, 32px);
+    font-size: clamp(1.25rem, 0.25rem + 5.33vw, 2.25rem);
     font-weight: 700;
+    padding: 2px 0px;
+    margin-left: 5%;
     margin-right: auto;
 }
 
 .statusBadge {
-    padding: clamp(4px, 0.8vw, 6px) clamp(10px, 1.5vw, 14px);
-    border-radius: 999px;
-    font-size: clamp(12px, 1.5vw, 16px);
+    padding: 2px clamp(10px, 1.5vw, 14px);
+    border-radius: 10px;
+    font-size: clamp(0.75rem, 0.375rem + 2vw, 1.125rem);
     font-weight: 600;
 }
 
 .statusBadge.open {
     background: #e5f3ea;
     color: #3F7D58;
-    border: 1px solid #3F7D58;
+    border: 2px solid #3F7D58;
 }
 
 .statusBadge.closed {
     background: #ffe4c4;
     color: #EF633D;
-    border: 1px solid #EF633D;
+    border: 2px solid #EF633D;
 }
 
 
@@ -80,10 +91,14 @@
    コンテンツ
 ================================= */
 .cardContents {
-    padding: clamp(12px, 2vw, 20px);
+    padding:
+      5px                      /* top */
+      clamp(12px, 2vw, 20px)   /* right */
+      5px                      /* bottom */
+      clamp(40px, 4vw, 60px);  /* left ←ここだけ大きく */
     display: flex;
     flex-direction: column;
-    gap: clamp(10px, 1.5vw, 16px);
+    gap: 4px clamp(10px, 1.5vw, 16px);
 }
 
 .row {
@@ -100,7 +115,8 @@
 }
 
 .tag {
-    font-size: clamp(18px, 2vw, 26px);
+    font-size: clamp(0.875rem, 0.25rem + 3.0vw, 1.5rem);
+    font-weight: 550;
     color: #3F7D58;
 }
 
@@ -110,7 +126,7 @@
     display: flex;
     align-items: center;
     gap: clamp(6px, 1vw, 10px);
-    font-size: clamp(18px, 2vw, 26px);
+    font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
     font-weight: 600;
     color: #2f4f3f;
 }
@@ -121,8 +137,8 @@
     align-items: center;
     justify-content: center;
 
-    width: clamp(30px, 3vw, 36px);
-    height: clamp(30px, 3vw, 36px);
+    width: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
+    height: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
 
     border-radius: 20%;
 }
@@ -139,13 +155,15 @@
    フッター
 ================================= */
 .cardFooter {
-    padding: clamp(12px, 2vw, 20px);
+    padding: 0px 5% 6px 5%;
     display: flex;
-    gap: clamp(12px, 2vw, 20px);
+    gap: clamp(12px, 2vw, 20px) 5%;
 }
 
 .cardFooter button {
     flex: 1;
-    font-size: clamp(18px, 2.2vw, 22px);
-    padding: clamp(8px, 1vw, 14px) 0;
+    font-size: 18px;
+    padding: 0px clamp(8px, 1vw, 14px);
+    height: clamp(40px, 8vw, 48px);
+    border: 2px solid #3F7D58;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -92,10 +92,10 @@
 ================================= */
 .cardContents {
     padding:
-      5px                      /* top */
-      clamp(12px, 2vw, 20px)   /* right */
-      5px                      /* bottom */
-      clamp(40px, 4vw, 60px);  /* left ←ここだけ大きく */
+      5px   /* top */
+      2%    /* right */
+      5px   /* bottom */
+      7%;   /* left */
     display: flex;
     flex-direction: column;
     gap: 4px clamp(10px, 1.5vw, 16px);
@@ -105,7 +105,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     align-items: center;
-    column-gap: clamp(16px, 3vw, 40px);
+    column-gap: 8px;
 }
 
 .tagsRow {
@@ -115,7 +115,7 @@
 }
 
 .tag {
-    font-size: clamp(0.875rem, 0.25rem + 3.0vw, 1.5rem);
+    font-size: clamp(0.875rem, 0.25rem + 3.5vw, 1.5rem);
     font-weight: 550;
     color: #3F7D58;
 }
@@ -162,7 +162,7 @@
 
 .cardFooter button {
     flex: 1;
-    font-size: 18px;
+    font-size: clamp(1rem, 0.5rem + 2.67vw, 1.5rem);
     padding: 0px clamp(8px, 1vw, 14px);
     height: clamp(40px, 8vw, 48px);
     border: 2px solid #3F7D58;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -13,12 +13,12 @@
     flex-direction: column;
 
     /* global.cssに統合 */
-    font-family: 
+    font-family:
         "Hiragino Kaku Gothic ProN",
         "Hiragino Sans",
         "Yu Gothic",
         "Meiryo",
-        "Noto Sans JP",;
+        "Noto Sans JP", ;
 }
 
 
@@ -33,8 +33,9 @@
 }
 
 .title {
-    font-size: clamp(1.25rem, 0.25rem + 5.33vw, 2.25rem);
+    font-size: clamp(1.0rem, 0.25rem + 4.5vw, 2.25rem);
     font-weight: 700;
+    color: #1E1E1E;
     padding: 2px 0px;
     margin-left: 5%;
     margin-right: auto;
@@ -43,7 +44,7 @@
 .statusBadge {
     padding: 2px clamp(10px, 1.5vw, 14px);
     border-radius: 10px;
-    font-size: clamp(0.75rem, 0.375rem + 2vw, 1.125rem);
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
     font-weight: 600;
 }
 
@@ -92,10 +93,14 @@
 ================================= */
 .cardContents {
     padding:
-      5px   /* top */
-      2%    /* right */
-      5px   /* bottom */
-      7%;   /* left */
+        5px
+        /* top */
+        2%
+        /* right */
+        5px
+        /* bottom */
+        7%;
+        /* left */
     display: flex;
     flex-direction: column;
     gap: 4px clamp(10px, 1.5vw, 16px);
@@ -115,7 +120,7 @@
 }
 
 .tag {
-    font-size: clamp(0.875rem, 0.25rem + 3.5vw, 1.5rem);
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
     font-weight: 550;
     color: #3F7D58;
 }
@@ -129,6 +134,9 @@
     font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
     font-weight: 600;
     color: #2f4f3f;
+    font-family:
+        "Yu Gothic";
+        
 }
 
 /* アイコン丸背景 */
@@ -137,8 +145,8 @@
     align-items: center;
     justify-content: center;
 
-    width: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
-    height: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
+    width: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
+    height: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
 
     border-radius: 20%;
 }
@@ -162,8 +170,8 @@
 
 .cardFooter button {
     flex: 1;
-    font-size: clamp(1rem, 0.5rem + 2.67vw, 1.5rem);
+    font-size: clamp(0.75rem, 0.5rem + 2.0vw, 1.5rem);
     padding: 0px clamp(8px, 1vw, 14px);
-    height: clamp(40px, 8vw, 48px);
+    height: clamp(34px, 8vw, 44px);
     border: 2px solid #3F7D58;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -33,7 +33,7 @@ const iconConfig = {
   shop: {
     icon1: <Sun />,
     icon2: <Moon />,
-    bg1: "#FFA726",
+    bg1: "#efab58",
     bg2: "#5C6BC0",
   },
   spot: {


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポット紹介カードの細かいデザインを修正しました。

## 変更の理由・背景
- デバイスの幅に応じてフォントなどの大きさを柔軟に変えるため。

## 変更内容
- フォントや余白、アイコンの大きさを画面の大きさに依存するように変更
- 文字とアイコンの色を微修正

## スクリーンショット（UI変更がある場合）
<img width="540" height="340" alt="スクリーンショット 2026-03-02 151907" src="https://github.com/user-attachments/assets/a2160a7f-35b2-4db7-8d5c-553ac05b6b47" />


## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 将来的に、営業ステータスにまもなく閉店追加する予定