### PR TITLE
Add:検索ページのテキストフィールドコンポーネントを追加しました

### DIFF
--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
@@ -11,25 +11,25 @@
 
 /* 通常枠線 */
 .searchField :global(.MuiOutlinedInput-notchedOutline) {
-    border-color: #3F7D58;
+    border-color: var(--primary-color);
     border-width: 3px;
 }
 
 /* hover */
 .searchField :global(.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline) {
-    border-color: #3F7D58;
+    border-color: var(--primary-color);
     border-width: 3px;
 }
 
 /* focus */
 .searchField :global(.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline) {
-    border-color: #3F7D58;
+    border-color: var(--primary-color);
     border-width: 3px;
 }
 
 /* アイコン色 */
 .icon {
-    color: #1b1b1b;
+    color: var(--text-black);
     width: 35px !important;
     height: 35px !important;
 }

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
@@ -1,0 +1,52 @@
+/* テキストフィールド全体のレイアウト */
+.searchField :global(.MuiOutlinedInput-root) {
+    border-radius: 15px;
+    height: 56px;
+}
+
+/* 文字サイズ調整 */
+.searchField :global(.MuiOutlinedInput-input) {
+    font-size: 1.2rem;
+}
+
+/* 通常枠線 */
+.searchField :global(.MuiOutlinedInput-notchedOutline) {
+    border-color: #3F7D58;
+    border-width: 3px;
+}
+
+/* hover */
+.searchField :global(.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline) {
+    border-color: #3F7D58;
+    border-width: 3px;
+}
+
+/* focus */
+.searchField :global(.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline) {
+    border-color: #3F7D58;
+    border-width: 3px;
+}
+
+/* アイコン色 */
+.icon {
+    color: #1b1b1b;
+    width: 35px !important;
+    height: 35px !important;
+}
+
+/* 検索ボタン */
+.searchButton {
+    padding: 0;
+    transition: box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+/* ホバー時 */
+.searchButton:hover {
+    background-color: rgba(0, 0, 0, 0.08);
+}
+
+/* 押したとき */
+.searchButton:active {
+    background-color: rgba(0, 0, 0, 0.15);
+    transform: scale(0.95);
+}

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, KeyboardEvent } from "react";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import IconButton from "@mui/material/IconButton";
+import { Search } from "lucide-react";
+import styles from "./SearchTextField.module.css";
+
+type Props = {
+  onSearch: (keyword: string) => void;
+  label?: string;
+};
+
+export const SearchTextField = ({ onSearch, label = "検索" }: Props) => {
+  const [value, setValue] = useState("");
+
+  const handleSearch = () => {
+    if (!value.trim()) return;
+    onSearch(value);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
+
+  return (
+    <TextField
+      fullWidth
+      variant="outlined"
+      label={label}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={handleKeyDown}
+      className={styles.searchField}
+      slotProps={{
+        input: {
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                onClick={handleSearch}
+                className={styles.searchButton}
+              >
+                <Search
+                  size={50}
+                  strokeWidth={3}
+                  className={styles.icon}
+                />
+              </IconButton>
+            </InputAdornment>
+          ),
+        },
+      }}
+    />
+  );
+};


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
検索ページ用のテキストフィールドと検索ボタンを合わせたコンポーネントを作成しました。

## 変更の理由・背景
- 検索ページに向け作成

## 変更内容
- テキストフィールド選択時にラベルが左上に移動

## スクリーンショット（UI変更がある場合）
<img width="871" height="94" alt="スクリーンショット 2026-03-03 163507" src="https://github.com/user-attachments/assets/2da41b85-ba64-411c-bf7a-dc34e6175a98" />
<img width="871" height="87" alt="スクリーンショット 2026-03-03 163805" src="https://github.com/user-attachments/assets/3b0d82be-38f9-49ac-93f0-d3dbe7c909c2" />


## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- cssで:globalを使用してみたが他の要素に干渉する可能性があるかもしれない(調べた限りでは大丈夫そうでした)

## その他
- 