### PR TITLE
Add: もっと詳しくを押すと、spots/にあるURLに飛ぶようにしました

### DIFF
--- a/miniApp/frontend/app/maps/page.tsx
+++ b/miniApp/frontend/app/maps/page.tsx
@@ -23,6 +23,7 @@ type SpotData = {
   isOpen: boolean;
   imageSrc: string;
   spotTags: string[];
+  detailURL: string;
   price1?: string;
   price2?: string;
   position: google.maps.LatLngLiteral;
@@ -65,6 +66,7 @@ export default function Map() {
       isOpen: true,
       imageSrc: "/sampleImage.png",
       spotTags: ["ラーメン", "豚骨", "待ち時間少", "禁煙"],
+      detailURL: "/spots/restaurant",
       price1: "￥:1500",
       price2: "￥:200~3000",
       position: { lat: 33.5905, lng: 130.3817 },
@@ -77,6 +79,7 @@ export default function Map() {
       isOpen: true,
       imageSrc: "/sampleImage.png",
       spotTags: ["うどん", "地元人気", "待ち時間少", "禁煙"],
+      detailURL: "/spots/restaurant",
       price1: "￥:1500",
       position: { lat: 33.5900, lng: 130.3998 },
     },
@@ -88,6 +91,7 @@ export default function Map() {
       isOpen: true,
       imageSrc: "/sampleImage.png",
       spotTags: ["ラーメン", "豚骨", "待ち時間少", "禁煙"],
+      detailURL: "/spots/restaurant",
       price1: "￥:1500",
       price2: "￥:200~3000",
       position: { lat: 33.5905, lng: 130.3857 },
@@ -100,6 +104,7 @@ export default function Map() {
       isOpen: true,
       imageSrc: "/sampleImage.png",
       spotTags: ["うどん", "地元人気", "待ち時間少", "禁煙"],
+      detailURL: "/spots/restaurant",
       price1: "￥:1500",
       position: { lat: 33.5900, lng: 130.3958 },
     },
@@ -252,6 +257,7 @@ export default function Map() {
                 isOpen={selectedSpot.isOpen}
                 imageSrc={selectedSpot.imageSrc}
                 spotTags={selectedSpot.spotTags}
+                detailURL={selectedSpot.detailURL}
                 price1={selectedSpot.price1}
                 price2={selectedSpot.price2}
                 onCloseClick={() => setSelectedSpot(null)}

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -5,11 +5,20 @@
     width: 100%;
     max-width: 600px;
     background: #f4f4f4;
-    border-radius: clamp(16px, 2vw, 24px);
+    border: 1.2px solid #c3c3c3;
+    border-radius: 24px;
     overflow: hidden;
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
     display: flex;
     flex-direction: column;
+
+    /* global.cssに統合 */
+    font-family: 
+        "Hiragino Kaku Gothic ProN",
+        "Hiragino Sans",
+        "Yu Gothic",
+        "Meiryo",
+        "Noto Sans JP",;
 }
 
 
@@ -19,33 +28,35 @@
 .cardHeader {
     display: flex;
     align-items: center;
-    padding: clamp(12px, 2vw, 20px);
+    padding-right: 8px;
     gap: clamp(8px, 1.5vw, 16px);
 }
 
 .title {
-    font-size: clamp(20px, 3.2vw, 32px);
+    font-size: clamp(1.25rem, 0.25rem + 5.33vw, 2.25rem);
     font-weight: 700;
+    padding: 2px 0px;
+    margin-left: 5%;
     margin-right: auto;
 }
 
 .statusBadge {
-    padding: clamp(4px, 0.8vw, 6px) clamp(10px, 1.5vw, 14px);
-    border-radius: 999px;
-    font-size: clamp(12px, 1.5vw, 16px);
+    padding: 2px clamp(10px, 1.5vw, 14px);
+    border-radius: 10px;
+    font-size: clamp(0.75rem, 0.375rem + 2vw, 1.125rem);
     font-weight: 600;
 }
 
 .statusBadge.open {
     background: #e5f3ea;
     color: #3F7D58;
-    border: 1px solid #3F7D58;
+    border: 2px solid #3F7D58;
 }
 
 .statusBadge.closed {
     background: #ffe4c4;
     color: #EF633D;
-    border: 1px solid #EF633D;
+    border: 2px solid #EF633D;
 }
 
 
@@ -80,10 +91,14 @@
    コンテンツ
 ================================= */
 .cardContents {
-    padding: clamp(12px, 2vw, 20px);
+    padding:
+      5px                      /* top */
+      clamp(12px, 2vw, 20px)   /* right */
+      5px                      /* bottom */
+      clamp(40px, 4vw, 60px);  /* left ←ここだけ大きく */
     display: flex;
     flex-direction: column;
-    gap: clamp(10px, 1.5vw, 16px);
+    gap: 4px clamp(10px, 1.5vw, 16px);
 }
 
 .row {
@@ -100,7 +115,8 @@
 }
 
 .tag {
-    font-size: clamp(18px, 2vw, 26px);
+    font-size: clamp(0.875rem, 0.25rem + 3.0vw, 1.5rem);
+    font-weight: 550;
     color: #3F7D58;
 }
 
@@ -110,7 +126,7 @@
     display: flex;
     align-items: center;
     gap: clamp(6px, 1vw, 10px);
-    font-size: clamp(18px, 2vw, 26px);
+    font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
     font-weight: 600;
     color: #2f4f3f;
 }
@@ -121,8 +137,8 @@
     align-items: center;
     justify-content: center;
 
-    width: clamp(30px, 3vw, 36px);
-    height: clamp(30px, 3vw, 36px);
+    width: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
+    height: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
 
     border-radius: 20%;
 }
@@ -139,13 +155,15 @@
    フッター
 ================================= */
 .cardFooter {
-    padding: clamp(12px, 2vw, 20px);
+    padding: 0px 5% 6px 5%;
     display: flex;
-    gap: clamp(12px, 2vw, 20px);
+    gap: clamp(12px, 2vw, 20px) 5%;
 }
 
 .cardFooter button {
     flex: 1;
-    font-size: clamp(18px, 2.2vw, 22px);
-    padding: clamp(8px, 1vw, 14px) 0;
+    font-size: 18px;
+    padding: 0px clamp(8px, 1vw, 14px);
+    height: clamp(40px, 8vw, 48px);
+    border: 2px solid #3F7D58;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -92,10 +92,10 @@
 ================================= */
 .cardContents {
     padding:
-      5px                      /* top */
-      clamp(12px, 2vw, 20px)   /* right */
-      5px                      /* bottom */
-      clamp(40px, 4vw, 60px);  /* left ←ここだけ大きく */
+      5px   /* top */
+      2%    /* right */
+      5px   /* bottom */
+      7%;   /* left */
     display: flex;
     flex-direction: column;
     gap: 4px clamp(10px, 1.5vw, 16px);
@@ -105,7 +105,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     align-items: center;
-    column-gap: clamp(16px, 3vw, 40px);
+    column-gap: 8px;
 }
 
 .tagsRow {
@@ -115,7 +115,7 @@
 }
 
 .tag {
-    font-size: clamp(0.875rem, 0.25rem + 3.0vw, 1.5rem);
+    font-size: clamp(0.875rem, 0.25rem + 3.5vw, 1.5rem);
     font-weight: 550;
     color: #3F7D58;
 }
@@ -162,7 +162,7 @@
 
 .cardFooter button {
     flex: 1;
-    font-size: 18px;
+    font-size: clamp(1rem, 0.5rem + 2.67vw, 1.5rem);
     padding: 0px clamp(8px, 1vw, 14px);
     height: clamp(40px, 8vw, 48px);
     border: 2px solid #3F7D58;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -168,10 +168,14 @@
     gap: clamp(12px, 2vw, 20px) 5%;
 }
 
-.cardFooter button {
+.cardFooter button,
+.cardFooter a {
     flex: 1;
     font-size: clamp(0.75rem, 0.5rem + 2.0vw, 1.5rem);
     padding: 0px clamp(8px, 1vw, 14px);
     height: clamp(34px, 8vw, 44px);
     border: 2px solid #3F7D58;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -13,12 +13,12 @@
     flex-direction: column;
 
     /* global.cssに統合 */
-    font-family: 
+    font-family:
         "Hiragino Kaku Gothic ProN",
         "Hiragino Sans",
         "Yu Gothic",
         "Meiryo",
-        "Noto Sans JP",;
+        "Noto Sans JP", ;
 }
 
 
@@ -33,8 +33,9 @@
 }
 
 .title {
-    font-size: clamp(1.25rem, 0.25rem + 5.33vw, 2.25rem);
+    font-size: clamp(1.0rem, 0.25rem + 4.5vw, 2.25rem);
     font-weight: 700;
+    color: #1E1E1E;
     padding: 2px 0px;
     margin-left: 5%;
     margin-right: auto;
@@ -43,7 +44,7 @@
 .statusBadge {
     padding: 2px clamp(10px, 1.5vw, 14px);
     border-radius: 10px;
-    font-size: clamp(0.75rem, 0.375rem + 2vw, 1.125rem);
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
     font-weight: 600;
 }
 
@@ -92,10 +93,14 @@
 ================================= */
 .cardContents {
     padding:
-      5px   /* top */
-      2%    /* right */
-      5px   /* bottom */
-      7%;   /* left */
+        5px
+        /* top */
+        2%
+        /* right */
+        5px
+        /* bottom */
+        7%;
+        /* left */
     display: flex;
     flex-direction: column;
     gap: 4px clamp(10px, 1.5vw, 16px);
@@ -115,7 +120,7 @@
 }
 
 .tag {
-    font-size: clamp(0.875rem, 0.25rem + 3.5vw, 1.5rem);
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
     font-weight: 550;
     color: #3F7D58;
 }
@@ -129,6 +134,9 @@
     font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
     font-weight: 600;
     color: #2f4f3f;
+    font-family:
+        "Yu Gothic";
+        
 }
 
 /* アイコン丸背景 */
@@ -137,8 +145,8 @@
     align-items: center;
     justify-content: center;
 
-    width: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
-    height: clamp(1.5rem, 0.75rem + 4vw, 2.0rem);
+    width: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
+    height: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
 
     border-radius: 20%;
 }
@@ -162,8 +170,8 @@
 
 .cardFooter button {
     flex: 1;
-    font-size: clamp(1rem, 0.5rem + 2.67vw, 1.5rem);
+    font-size: clamp(0.75rem, 0.5rem + 2.0vw, 1.5rem);
     padding: 0px clamp(8px, 1vw, 14px);
-    height: clamp(40px, 8vw, 48px);
+    height: clamp(34px, 8vw, 44px);
     border: 2px solid #3F7D58;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -33,7 +33,7 @@ const iconConfig = {
   shop: {
     icon1: <Sun />,
     icon2: <Moon />,
-    bg1: "#FFA726",
+    bg1: "#efab58",
     bg2: "#5C6BC0",
   },
   spot: {

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -52,6 +52,7 @@ type Props = {
     isOpen?: boolean;   // 営業中かどうか
     imageSrc: string;   // 画像URL
     spotTags: string[]; // タグの配列
+    detailURL: string; // 詳細のURL
     price1?: string;    // 飲食店: ランチ価格帯     観光地: 大人入場料
     price2?: string;    // 飲食店: ディナー価格帯   観光地: 小学生以下入場料
     onRouteClick: () => void;   // ルート検索ボタンの動作
@@ -65,6 +66,7 @@ export const SpotCard = ({
     isOpen,
     imageSrc,
     spotTags,
+    detailURL,
     price1,
     price2,
     onRouteClick,
@@ -154,7 +156,7 @@ export const SpotCard = ({
                 </div>
 
                 <div className={styles.cardFooter}>
-                    <Button onClick={onDetailClick} variant="contained" href='a'>
+                    <Button onClick={onDetailClick} variant="contained" href={detailURL}>
                     もっと詳しく
                     </Button>
                     <Button onClick={onRouteClick} variant="outlined">

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -154,7 +154,7 @@ export const SpotCard = ({
                 </div>
 
                 <div className={styles.cardFooter}>
-                    <Button onClick={onDetailClick} variant="contained">
+                    <Button onClick={onDetailClick} variant="contained" href='a'>
                     もっと詳しく
                     </Button>
                     <Button onClick={onRouteClick} variant="outlined">


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
もっと詳しくを押すと、spots/にあるURLに飛ぶようにしました
## 変更の理由・背景
- 詳しくを押しても特定のページに飛べなかったため。

## 変更内容
- PropsでdetailURLを受け取り、それをボタンのもっと詳しくのButtonコンポーネントのhrefに渡すようにしました
- SpotData型にdetailURLを追加しました
- ボタンにaタグ時のCSSを追加し、hrefでURLを追加しても見た目が変わらないようにしました

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 一応不都合がないか確認してほしいです！
- もしかしたらすでにほかのブランチで変更しちゃってるかもしれないからコンフリクトが起きたらごめんなさい😢 

## その他
- 特になし