### PR TITLE
タグ・キーワード検索APIの追加

### DIFF
--- a/miniApp/frontend/app/api/search/tag/route.ts
+++ b/miniApp/frontend/app/api/search/tag/route.ts
@@ -1,0 +1,69 @@
+// キャッシュをクリア
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+    try {
+        // supabaseクライアント
+        const supabase = await createClient();
+        // クエリを取り出す
+        const { searchParams } = new URL(request.url);
+        const options = searchParams.get('options');
+        // バリデーション
+        if (!options) {
+            return NextResponse.json([], { status: 200 });
+        }
+
+        // タグを検索
+        const { data, error } = await supabase
+            // 将来的にはSupabase CLI(または別ファイル)でテーブル名,カラム名を管理
+            .from('tags')
+            .select(`
+                spot_tags (
+                    spots (
+                        id,
+                        name,        pricing,
+                        latitude,
+                        longitude,
+                        spot_tags (
+                            tags (
+                                detail 
+                            )
+                        )
+
+                    )
+                )
+            `)
+            .eq('detail', options)
+            .single();
+
+        if (error) {
+            // タグがヒットしなかった場合、空配列を返す
+            if (error.code === 'PGRST116') {
+                return NextResponse.json([]);
+            }
+            
+            return NextResponse.json({ error: error.message }, { status: 500 });
+        }
+
+        // mapでjsonを展開
+        const formattedData = data.spot_tags.map((item: any) => {
+            const temp = item.spots;
+            return {
+                id: temp.id,
+                name: temp.name,
+                latitude: temp.latitude,
+                longitude: temp.longitude,
+                tags: temp.spot_tags.map((st: any) => st.tags.detail)
+            };
+        });
+
+        return NextResponse.json(formattedData);
+    } catch (err) {
+        console.error('Unexpected Error:', err);
+        return NextResponse.json({ error: 'サーバー内部エラーが発生しました' }, { status: 500 });
+    }
+}
+

--- a/miniApp/frontend/app/api/search/tag/route.ts
+++ b/miniApp/frontend/app/api/search/tag/route.ts
@@ -49,16 +49,19 @@ export async function GET(request: Request) {
         }
 
         // mapでjsonを展開
-        const formattedData = data.spot_tags.map((item: any) => {
-            const temp = item.spots;
-            return {
-                id: temp.id,
-                name: temp.name,
-                latitude: temp.latitude,
-                longitude: temp.longitude,
-                tags: temp.spot_tags.map((st: any) => st.tags.detail)
-            };
-        });
+        const formattedData = data.spot_tags
+            .filter((item: any) => item.spots !== null)
+            .map((item: any) => {
+                const temp = item.spots;
+                return {
+                    id: temp?.id,
+                    name: temp?.name,
+                    pricing: temp?.pricing,
+                    latitude: temp?.latitude,
+                    longitude: temp?.longitude,
+                    tags: temp?.spot_tags?.map((st: any) => st.tags?.detail).filter(Boolean) || []
+                };
+            });
 
         return NextResponse.json(formattedData);
     } catch (err) {


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
概要
  タグ（条件）を指定して、関連する店舗（スポット）情報をSupabaseから取得する検索API（/api/search/tag）を新規作成しました。

変更の理由・背景
   - 検索ページなどから特定のタグ（例：「もつ鍋」や「安い」など）に紐づく店舗一覧をマップページ等で表示するため、データベースから柔軟に検索結果を取得するバックエンド処理が必要になったため。
   - 店舗カードの表示に価格情報（pricing）が必要であり、またデータ欠損時にアプリがクラッシュするのを防ぐ堅牢なAPIにする必要があったため。

変更内容
   - app/api/search/tag/route.ts を新規作成し、URLクエリパラメータ（?options=〇〇）からタグ名を受け取り検索する処理を実装しました。
   - Supabaseのリレーション（tags → spot_tags → spots）を活用し、該当するスポットの緯度経度や付随する全タグを取得できるようにしました。
   - 取得した店舗データに価格情報（pricing）をマッピングする処理を追加しました。
   - リレーションデータが存在しない（null）場合でもアプリがクラッシュしないよう、オプショナルチェーン（?.）と filter を用いた安全対策（nullチェック）を追加しました。

スクリーンショット（UI変更がある場合）
  APIの追加・修正のみのため、UIの変更はありません。

動作確認
   - [x] ローカルでビルドが通ることを確認
   - 取得データ例 : [{"id":11,"name":"もつ鍋
     仙頭","pricing":"￥4,000～￥4,999","latitude":33.5881670228536,"longitude":130.412500181567,"tags":["クレジットカード可","もつ鍋","デート","予約おすすめ","キャナルシティ周辺","📍博多","👤ひとりで","👥ふた
     りで","👪家族・子どもと","👨‍👩‍👧‍👦3人以上"]}]

レビューしてほしい点・気になっている点
   - 現在、URLのクエリパラメータ名を options として受け取っていますが、フロントエンド側の実装に合わせてより直感的な tag や keyword 等に変更したほうが良いか、ご意見をいただきたいです。
   - 現状は export const dynamic = 'force-dynamic'; で毎回DBへアクセスしていますが、店舗データやタグの更新頻度を踏まえて、Next.jsのISR（例：revalidate）を用いたキャッシュ戦略を導入するべきか気になっています。

その他
   - 現状ソースコード内に any 型が一部残っていますが、これらは後日Supabase CLI等で型定義を自動生成した際に、まとめて厳密な型へ置き換える想定です。