### PR TITLE
マップページ初期化時に、全スポットの位置・種類を取得するapiの追加

### DIFF
--- a/miniApp/frontend/app/api/spotsPos/route.ts
+++ b/miniApp/frontend/app/api/spotsPos/route.ts
@@ -1,0 +1,52 @@
+// キャッシュを無効化
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET() {
+    try {
+        // supabaseクライアント
+        const supabase = await createClient();
+
+        // 全スポットのID、座標、種類を取得
+        // 将来的にはSupabase CLI(または別ファイル)でテーブル名,カラム名を管理
+        const { data, error } = await supabase
+            .from('spots')
+            .select(`
+                id,
+                latitude,
+                longitude,
+                placeType
+            `);
+
+        if (error) {
+            return NextResponse.json({ error: error.message }, { status: 500 });
+        }
+
+        // フロントエンドの MinimalSpotData 形式に合わせて変換
+        // placeType に基づいて pinKind を決定するロジック（仮）
+        const formattedData = data.map((spot: any) => {
+            let pinKind = "/FoodPin.svg"; // デフォルト
+            
+            if (spot.placeType === "Cafe") pinKind = "/ChairPin.svg";
+            else if (spot.placeType === "Sightseeing") pinKind = "/CameraPin.svg";
+            else if (spot.placeType === "Shop") pinKind = "/GiftPin.svg";
+            
+            return {
+                id: spot.id,
+                position: {
+                    lat: spot.latitude,
+                    lng: spot.longitude
+                },
+                pinKind: pinKind
+            };
+        });
+
+        return NextResponse.json(formattedData);
+
+    } catch (err) {
+        console.error('Unexpected Error:', err);
+        return NextResponse.json({ error: 'サーバー内部エラーが発生しました' }, { status: 500 });
+    }
+}

--- a/miniApp/frontend/app/api/spotsPos/route.ts
+++ b/miniApp/frontend/app/api/spotsPos/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
                 id,
                 latitude,
                 longitude,
-                placeType
+                place_type
             `);
 
         if (error) {
@@ -25,7 +25,7 @@ export async function GET() {
         }
 
         // フロントエンドの MinimalSpotData 形式に合わせて変換
-        // placeType に基づいて pinKind を決定するロジック（仮）
+        // place_type に基づいて pin画像 を決定するロジック（修正必須）
         const formattedData = data.map((spot: any) => {
             let pinKind = "/FoodPin.svg"; // デフォルト
             


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
マップページを開いた際の初期表示用として、データベースに登録されている全スポットの「最小限のデータ（緯度・経度など）」のみを高速に取得するAPI（/api/spotsPos）を新規作成しました。

## 変更の理由・背景
- マップページで100〜1000件規模の店舗ピンを表示する際、画像や紹介文などの全データを一度に取得すると通信量が膨大になり（数百KB〜1MB以上）、ロード時間が長くなってUXが悪化するため。
- 初期ロード時は「ピンを描画するためだけの最小限のデータ（IDと座標）」のみを取得し、詳細データはピンがクリックされた時に都度取得する（遅延読み込み）設計へとアーキテクチャを移行するため。

## 変更内容
- app/api/spotsPos/route.ts を新規作成しました。
- spots テーブルから id, latitude, longitude, placeType の4カラムのみを全件取得する処理を実装しました。
- 取得したデータを、マップコンポーネントで定義している MinimalSpotData 形式（id, position: { lat, lng }, pinKind）に整形してJSONで返すようにしました。

## スクリーンショット（UI変更がある場合）
なし

## 動作確認
- [x] ローカルでビルドが通ることを確認
- [x] /spotsPos-test (テストページ)にアクセスし、DBに登録されているスポットのID・座標・ピン種別が全件取得できていることを確認
## レビューしてほしい点・気になっている点
 - 【要修正事項】ピン画像の分岐ロジックについて
    現在、取得した placeType の文字列（"Cafe", "Sightseeing" など）を見て、pinKind（表示するSVGピンのパス）を割り当てる if/else文をAPI内に仮で書いています。しかし、今後カテゴリが増えた際などの保守性を考えると、この分岐処理は定数ファイルやDB側で管理する、あるいはクライアント側でタグ情報を元に決定するなど、より良い設計へ修正・リファク
  タリングする必要があると考えています。ご意見をお願いします。

## その他
- 