### PR TITLE
fix:カラム名を修正しました

### DIFF
--- a/miniApp/frontend/app/api/spotcard/route.ts
+++ b/miniApp/frontend/app/api/spotcard/route.ts
@@ -31,6 +31,10 @@ export async function GET(request: Request) {
                     tags (
                         detail 
                     )
+                ),
+                assets (
+                    url,
+                    is_cardthumbnail
                 )
             `)
             .eq('id', id)
@@ -44,6 +48,10 @@ export async function GET(request: Request) {
             return NextResponse.json({ error: 'スポットが見つかりませんでした' }, { status: 404 });
         }
 
+        // サムネイル画像を取得（is_cardthumbnailがtrueのもの）
+        const thumbnail = data.assets?.find((a: any) => a.is_cardthumbnail === true);
+        const imageSrc = thumbnail?.url || "/sampleImage.png"; // 見つからなければデフォルト画像
+
         // MapSpotData (UI用) の形式に整形
         const formattedData = {
             id: data.id,
@@ -51,7 +59,7 @@ export async function GET(request: Request) {
             // 本来はカテゴリ等から判定するが、一旦共通のパスをセット（フロントエンドで上書き可能）
             pinKind: data.place_type === "Restaurant" ? "/FoodPin.svg" : "/CameraPin.svg",
             spotName: data.name,
-            imageSrc: "/sampleImage.png", // 本来はDBの画像URLを使用する
+            imageSrc: imageSrc,
             spotTags: data.spot_tags?.map((st: any) => st.tags?.detail).filter(Boolean) || [],
             detailURL: `/spots/restaurant/${data.id}`,
             price1: typeof data.pricing === 'string' ? data.pricing : "価格情報なし", // pricingの形式に合わせて調整が必要

--- a/miniApp/frontend/app/api/spotcard/route.ts
+++ b/miniApp/frontend/app/api/spotcard/route.ts
@@ -1,0 +1,71 @@
+// キャッシュを無効化
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+    try {
+        const supabase = await createClient();
+        
+        // URLからIDを取得 (?id=123)
+        const { searchParams } = new URL(request.url);
+        const id = searchParams.get('id');
+
+        if (!id) {
+            return NextResponse.json({ error: 'IDが指定されていません' }, { status: 400 });
+        }
+
+        // 指定されたIDのスポット詳細情報を取得
+        const { data, error } = await supabase
+            .from('spots')
+            .select(`
+                id,
+                name,
+                place_type,
+                pricing,
+                latitude,
+                longitude,
+                updated_at,
+                spot_tags (
+                    tags (
+                        detail 
+                    )
+                )
+            `)
+            .eq('id', id)
+            .single();
+
+        if (error) {
+            return NextResponse.json({ error: error.message }, { status: 500 });
+        }
+
+        if (!data) {
+            return NextResponse.json({ error: 'スポットが見つかりませんでした' }, { status: 404 });
+        }
+
+        // MapSpotData (UI用) の形式に整形
+        const formattedData = {
+            id: data.id,
+            spotKind: data.place_type,
+            // 本来はカテゴリ等から判定するが、一旦共通のパスをセット（フロントエンドで上書き可能）
+            pinKind: data.place_type === "Restaurant" ? "/FoodPin.svg" : "/CameraPin.svg",
+            spotName: data.name,
+            imageSrc: "/sampleImage.png", // 本来はDBの画像URLを使用する
+            spotTags: data.spot_tags?.map((st: any) => st.tags?.detail).filter(Boolean) || [],
+            detailURL: `/spots/restaurant/${data.id}`,
+            price1: typeof data.pricing === 'string' ? data.pricing : "価格情報なし", // pricingの形式に合わせて調整が必要
+            position: {
+                lat: data.latitude,
+                lng: data.longitude
+            },
+            updatedAt: new Date(data.updated_at)
+        };
+
+        return NextResponse.json(formattedData);
+
+    } catch (err) {
+        console.error('Unexpected Error:', err);
+        return NextResponse.json({ error: 'サーバー内部エラーが発生しました' }, { status: 500 });
+    }
+}


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
マップ上でピンをクリックした際に、該当スポットの詳細情報（カード用データ）とサムネイル画像を取得するAPI（/api/spotcard）を新規作成しました。

## 変更の理由・背景
- マップの初期表示時は最小限のデータのみを読み込み、ピンがクリックされたタイミングで詳細データを都度取得する（遅延読み込み）設計へと移行したため。

## 変更内容
- app/api/spotcard/route.ts を新規作成しました。
- クエリパラメータ（?id=）で受け取ったIDをもとに、spots テーブルから詳細情報とタグ情報を取得する処理を実装しました。

## スクリーンショット（UI変更がある場合）
なし

## 動作確認
- [x] ローカルでビルドが通ることを確認
- [x] /spotcard-test にて任意のIDを指定し、該当店舗の詳細データと紐づくサムネイル画像（is_cardthumbnail: true のもの）のURLが正しく取得できることを確認

## レビューしてほしい点・気になっている点
- 現在、カードに表示する「営業時間から計算した営業状況（isOpen）」は仮で trueに設定しています。今後、google提供のapiを用いて取得する予定です。

## その他
- 