### PR TITLE
fix:マップページおよびカードのローディングをアニメーションに変更しました

### DIFF
--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -11,6 +11,8 @@ import {
 import { LocateFixed } from "lucide-react";
 import { IconButton } from "@mui/material";
 import { SpotCard } from "@/components/atoms/spotCard/SpotCard";
+import { SpotCardSkeleton } from "@/components/atoms/spotCard/SpotCardSkeleton";
+import Loading from "@/components/atoms/loading/Loading";
 import { SearchTextField } from "@/components/atoms/searchTextField/SearchTextField";
 import { MenuButton } from "@/components/atoms/menuButton/MenuButton";
 import { MenuDrawer } from "@/components/organisms/menuDrawer/MenuDrawer";
@@ -47,6 +49,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   // state管理
   const [selectedSpot, setSelectedSpot] = useState<null | MapSpotData>(null);  // 選択中の詳細データ
+  const [isCardLoading, setIsCardLoading] = useState(false); // カードのロード状態
   const mapRef = useRef<google.maps.Map | null>(null);
   const [currentPos, setCurrentPos] = useState<google.maps.LatLngLiteral | null>(null);
   const [locationStatus, setLocationStatus] = useState<'loading' | 'allowed' | 'denied'>('loading');
@@ -231,7 +234,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
     }
   };
 
-  if (!isLoaded) return <div>Loading...</div>;
+  if (!isLoaded) return <Loading />;
 
   return (
     <div className={styles.mapPage}>
@@ -305,6 +308,24 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
                 setSelectedSpot(alreadyFetched);
                 return;
               }
+              
+              setIsCardLoading(true);
+              // スケルトン表示用のダミーデータをセット
+              const dummySpot: MapSpotData = {
+                id: spot.id,
+                position: spot.position,
+                pinKind: spot.pinKind,
+                spotKind: "spot",
+                spotName: "",
+                isOpen: false,
+                imageSrc: "",
+                spotTags: [],
+                detailURL: "",
+                updatedAt: new Date()
+              };
+              setDisplayCards([dummySpot]);
+              setSelectedSpot(dummySpot);
+
               // APIから詳細を取得
               try {
                 const response = await fetch(`/api/spotcard?id=${spot.id}`);
@@ -313,7 +334,13 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
                   setDisplayCards([detailData]); // リストを上書きして選択状態にする
                   setSelectedSpot(detailData);
                 }
-              } catch (e) { console.error(e); }
+              } catch (e) { 
+                console.error(e); 
+                setSelectedSpot(null);
+                setDisplayCards([]);
+              } finally {
+                setIsCardLoading(false);
+              }
             }}
             icon={{
               url: spot.pinKind,
@@ -343,21 +370,25 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
                     cardRefs.current[spot.id] = el;
                   }}
                 >
-                  <SpotCard
-                    spotKind={spot.spotKind}
-                    spotName={spot.spotName}
-                    isOpen={spot.isOpen}
-                    imageSrc={spot.imageSrc}
-                    spotTags={spot.spotTags}
-                    detailURL={spot.detailURL}
-                    price1={spot.price1}
-                    price2={spot.price2}
-                    updatedAt={spot.updatedAt}
-                    onCloseClick={() => {
-                      setSelectedSpot(null);
-                      setDisplayCards([]);
-                    }}
-                  />
+                  {isCardLoading && selectedSpot?.id === spot.id ? (
+                    <SpotCardSkeleton />
+                  ) : (
+                    <SpotCard
+                      spotKind={spot.spotKind}
+                      spotName={spot.spotName}
+                      isOpen={spot.isOpen}
+                      imageSrc={spot.imageSrc}
+                      spotTags={spot.spotTags}
+                      detailURL={spot.detailURL}
+                      price1={spot.price1}
+                      price2={spot.price2}
+                      updatedAt={spot.updatedAt}
+                      onCloseClick={() => {
+                        setSelectedSpot(null);
+                        setDisplayCards([]);
+                      }}
+                    />
+                  )}
                 </div>
               ))}
               <div className={styles.spacer} />

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -110,6 +110,22 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
     if (locationStatus === 'loading' || !currentPos) return;
 
     const fetchTop5 = async () => {
+      setIsCardLoading(true);
+      const dummySpot: MapSpotData = {
+        id: -1,
+        position: currentPos,
+        pinKind: "",
+        spotKind: "spot",
+        spotName: "",
+        isOpen: false,
+        imageSrc: "",
+        spotTags: [],
+        detailURL: "",
+        updatedAt: new Date()
+      };
+      setDisplayCards([dummySpot]);
+      setSelectedSpot(dummySpot);
+
       const url = new URL(window.location.origin + '/api/search');
       if (activeKeyword) url.searchParams.append('keyword', activeKeyword);
       if (searchOptions) url.searchParams.append('options', searchOptions);
@@ -162,6 +178,10 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
         }
       } catch (error) {
         console.error("検索API呼び出しエラー:", error);
+        setSelectedSpot(null);
+        setDisplayCards([]);
+      } finally {
+        setIsCardLoading(false);
       }
     };
 


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要

## 変更の理由・背景
- マップ画面における各種ローディング表示（スケルトン表示および全体ローディング）の実装と改善を行いました。

## 変更内容
- マップ上のピンをタップしてから店舗情報（API）の取得が完了するまでの間、画面上に反応がなく、ユーザーにロ
     ード中であることが伝わりにくい状態だったため。
- Google Maps
     APIの初期ロード時の表示が単なるテキスト（<div>Loading...</div>）となっており、アプリ全体の統一されたロ
     ーディングUIと異なっていたため。

## スクリーンショット（UI変更がある場合）
<img width="767" height="1596" alt="スクリーンショット 2026-04-16 002304" src="https://github.com/user-attachments/assets/fffa56be-fd50-4bef-b34e-039ee352b886" />
<img width="765" height="1592" alt="スクリーンショット 2026-04-16 002313" src="https://github.com/user-attachments/assets/a56e5070-8055-45f1-93a1-75c275102eb2" />


## 動作確認
- [ x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- スケルトン表示への切り替わりやアニメーションの挙動に違和感がないかご確認をお願いします。

## その他
- 