### PR TITLE
Feat: place_type に基づく動的なピン画像と詳細URLの生成

### DIFF
--- a/miniApp/frontend/app/api/search/route.ts
+++ b/miniApp/frontend/app/api/search/route.ts
@@ -117,16 +117,30 @@ export async function GET(request: Request) {
             const thumbnail = item.assets?.find((a: SpotAsset) => a.is_cardthumbnail === true);
             const imageSrc = thumbnail?.url || "/sampleImage.png";
 
+            // place_type に基づいて pin画像 と 詳細URL を決定
+            const type = item.place_type.toLowerCase();
+            let pinKind = "/FoodPin.svg";
+            let detailURL = `/spots/restaurant/${item.id}`;
+
+            if (type === "cafe" || type === "resting_spot") {
+                pinKind = "/ChairPin.svg";
+                detailURL = type === "cafe" ? `/spots/restaurant/${item.id}` : `/spots/resting/${item.id}`;
+            } else if (type === "sightseeing" || type === "sightseeing_spot") {
+                pinKind = "/CameraPin.svg";
+                detailURL = `/spots/sightseeing/${item.id}`;
+            } else if (type === "shop" || type === "gift_spot") {
+                pinKind = "/GiftPin.svg";
+                detailURL = `/spots/shop/${item.id}`;
+            }
+
             return {
                 id: item.id,
                 spotKind: item.place_type,
-                pinKind: item.place_type === "restaurant" ? "/FoodPin.svg" : 
-                         item.place_type === "sightseeing_spot" ? "/CameraPin.svg" : 
-                         item.place_type === "resting_spot" ? "/ChairPin.svg" : "/GiftPin.svg",
+                pinKind: pinKind,
                 spotName: item.name,
                 imageSrc: imageSrc,
                 spotTags: item.spot_tags?.map((st: SpotTag) => st.tags?.detail).filter(Boolean) || [],
-                detailURL: `/spots/restaurant/${item.id}`,
+                detailURL: detailURL,
                 price1: typeof item.pricing === 'string' ? item.pricing : "価格情報なし",
                 position: {
                     lat: typeof item.latitude === 'string' ? parseFloat(item.latitude) : item.latitude,

--- a/miniApp/frontend/app/api/spotcard/route.ts
+++ b/miniApp/frontend/app/api/spotcard/route.ts
@@ -93,12 +93,27 @@ export async function GET(request: Request) {
             }
         }
 
+        // place_type に基づいて pin画像 と 詳細URL を決定
+        const type = data.place_type.toLowerCase();
+        let pinKind = "/FoodPin.svg";
+        let detailURL = `/spots/restaurant/${data.id}`;
+
+        if (type === "cafe" || type === "resting_spot") {
+            pinKind = "/ChairPin.svg";
+            detailURL = type === "cafe" ? `/spots/restaurant/${data.id}` : `/spots/resting/${data.id}`;
+        } else if (type === "sightseeing" || type === "sightseeing_spot") {
+            pinKind = "/CameraPin.svg";
+            detailURL = `/spots/sightseeing/${data.id}`;
+        } else if (type === "shop" || type === "gift_spot") {
+            pinKind = "/GiftPin.svg";
+            detailURL = `/spots/shop/${data.id}`;
+        }
+
         // MapSpotData (UI用) の形式に整形
         const formattedData = {
             id: data.id,
             spotKind: data.place_type,
-            // 本来はカテゴリ等から判定するが、一旦共通のパスをセット（フロントエンドで上書き可能）
-            pinKind: data.place_type === "restaurant" ? "/FoodPin.svg" : "/CameraPin.svg",
+            pinKind: pinKind,
             spotName: data.name,
             isOpen: isOpen,
             imageSrc: imageSrc,
@@ -107,7 +122,7 @@ export async function GET(request: Request) {
                 if (Array.isArray(tags)) return tags[0]?.detail;
                 return (tags as { detail: string } | null)?.detail;
             }).filter(Boolean) || [],
-            detailURL: `/spots/restaurant/${data.id}`,
+            detailURL: detailURL,
             price1: typeof data.pricing === 'string' ? data.pricing : "価格情報なし", // pricingの形式に合わせて調整が必要
             position: {
                 lat: parseFloat(data.latitude),

--- a/miniApp/frontend/app/favorites/page.tsx
+++ b/miniApp/frontend/app/favorites/page.tsx
@@ -101,8 +101,30 @@ const FavoritesPage = () => {
     return <Loading />;
   }
 
-  const restaurants = favorites.filter((f) => f.placeType === "restaurant" || f.placeType === "飲食店");
-  const otherSpots = favorites.filter((f) => f.placeType !== "restaurant" && f.placeType !== "飲食店");
+  const getDetailPath = (placeType: string, id: number) => {
+    const type = placeType.toLowerCase();
+    if (type === "restaurant" || type === "cafe" || type === "飲食店") {
+      return `/spots/restaurant/${id}`;
+    }
+    if (type === "sightseeing" || type === "sightseeing_spot") {
+      return `/spots/sightseeing/${id}`;
+    }
+    if (type === "shop" || type === "gift_spot") {
+      return `/spots/shop/${id}`;
+    }
+    if (type === "resting_spot") {
+      return `/spots/resting/${id}`;
+    }
+    return `/spots/sightseeing/${id}`; // デフォルト
+  };
+
+  const isRestaurant = (placeType: string) => {
+    const type = placeType.toLowerCase();
+    return type === "restaurant" || type === "cafe" || type === "飲食店";
+  };
+
+  const restaurants = favorites.filter((f) => isRestaurant(f.placeType));
+  const otherSpots = favorites.filter((f) => !isRestaurant(f.placeType));
 
   return (
     <div className={styles.container}>
@@ -126,7 +148,7 @@ const FavoritesPage = () => {
                     <span className={styles.cardName}>{item.name}</span>
                   </div>
                   <div className={styles.cardFooter}>
-                    <Link href={`/spots/restaurant/${item.id}`} passHref>
+                    <Link href={getDetailPath(item.placeType, item.id)} passHref>
                       <Button
                         variant="contained"
                         className={styles.detailButton}
@@ -164,7 +186,7 @@ const FavoritesPage = () => {
                     <span className={styles.cardName}>{item.name}</span>
                   </div>
                   <div className={styles.cardFooter}>
-                    <Link href={`/spots/sightseeing/${item.id}`} passHref>
+                    <Link href={getDetailPath(item.placeType, item.id)} passHref>
                       <Button
                         variant="contained"
                         className={styles.detailButton}

--- a/miniApp/frontend/app/maps/page.tsx
+++ b/miniApp/frontend/app/maps/page.tsx
@@ -29,18 +29,23 @@ export default async function MapPage({ searchParams }: Props) {
 
   const initialSpots: MinimalSpotData[] = (data || []).map((spot: { id: number; latitude: number | string; longitude: number | string; place_type: string }) => {
       let pinKind = "/FoodPin.svg";
-      if (spot.place_type === "restaurant") pinKind = "/FoodPin.svg";
-      else if (spot.place_type === "sightseeing_spot") pinKind = "/CameraPin.svg";
-      else if (spot.place_type === "resting_spot") pinKind = "/ChairPin.svg";
-      else if (spot.place_type === "gift_spot") pinKind = "/GiftPin.svg";
-      
+      const type = spot.place_type.toLowerCase();
+
+      if (type === "cafe" || type === "resting_spot") {
+        pinKind = "/ChairPin.svg";
+      } else if (type === "sightseeing" || type === "sightseeing_spot") {
+        pinKind = "/CameraPin.svg";
+      } else if (type === "shop" || type === "gift_spot") {
+        pinKind = "/GiftPin.svg";
+      }
+
       return {
           id: spot.id,
-          position: { 
-              lat: typeof spot.latitude === 'string' ? parseFloat(spot.latitude) : spot.latitude, 
-              lng: typeof spot.longitude === 'string' ? parseFloat(spot.longitude) : spot.longitude 
+          position: {
+              lat: typeof spot.latitude === 'string' ? parseFloat(spot.latitude) : spot.latitude,
+              lng: typeof spot.longitude === 'string' ? parseFloat(spot.longitude) : spot.longitude,
           },
-          pinKind: pinKind
+          pinKind: pinKind,
       };
   });
 

--- a/miniApp/frontend/app/page.tsx
+++ b/miniApp/frontend/app/page.tsx
@@ -1,31 +1,5 @@
-"use client";
-import { useLIFF } from "../providers/liff-providers";
-import styles from "./page.module.css";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  const { liff, liffError } = useLIFF();
-
-  return (
-    <div>
-      <main className={styles.main}>
-        <h1>create-liff-app</h1>
-        {liff && <p>LIFF init succeeded.</p>}
-        {liffError && (
-          <>
-            <p>LIFF init failed.</p>
-            <p>
-              <code>{liffError}</code>
-            </p>
-          </>
-        )}
-        <a
-          href="https://developers.line.biz/ja/docs/liff/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          LIFF Documentation
-        </a>
-      </main>
-    </div>
-  );
+  redirect("/maps");
 }

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -53,7 +53,8 @@ export default function RestaurantDetailPage({ params }: Props) {
         supabase.from('spot_tags').select('tags(detail)').eq('spot_id', spotId)
       ]);
 
-      if (spotRes.error || !spotRes.data || spotRes.data.place_type !== 'restaurant') {
+      const type = (spotRes.data.place_type || "").toLowerCase();
+      if (spotRes.error || !spotRes.data || (type !== 'restaurant' && type !== 'cafe')) {
         setHasError(true);
         setLoading(false);
         return;

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -45,7 +45,8 @@ export default function RestingDetailPage({ params }: Props) {
         supabase.from('spot_tags').select('tags(detail)').eq('spot_id', spotId)
       ]);
 
-      if (spotRes.error || !spotRes.data || spotRes.data.place_type !== 'resting_spot') {
+      const type = (spotRes.data.place_type || "").toLowerCase();
+      if (spotRes.error || !spotRes.data || type !== 'resting_spot') {
         setHasError(true);
         setLoading(false);
         return;

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -49,7 +49,8 @@ export default function ShopDetailPage({ params }: Props) {
         supabase.from('spot_tags').select('tags(detail)').eq('spot_id', spotId)
       ]);
 
-      if (spotRes.error || !spotRes.data || spotRes.data.place_type !== 'shop') {
+      const type = (spotRes.data.place_type || "").toLowerCase();
+      if (spotRes.error || !spotRes.data || (type !== 'shop' && type !== 'gift_spot')) {
         setHasError(true);
         setLoading(false);
         return;

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -46,7 +46,8 @@ export default function SightseeingDetailPage({ params }: Props) {
         supabase.from('spot_tags').select('tags(detail)').eq('spot_id', spotId)
       ]);
 
-      if (spotRes.error || !spotRes.data || spotRes.data.place_type !== 'sightseeing_spot') {
+      const type = (spotRes.data.place_type || "").toLowerCase();
+      if (spotRes.error || !spotRes.data || (type !== 'sightseeing_spot' && type !== 'sightseeing')) {
         setHasError(true);
         setLoading(false);
         return;


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
place_type に基づく動的なピン画像と詳細URLの生成
## 変更の理由・背景
- issue解消のため

## 変更内容
- API (search, spotcard) において place_type から適切なアイコンと遷移先 URL を判定するロジックを追加
- お気に入りページおよびマップページでのスポット種別判定とリンク生成を改善 #72  
- 各スポット詳細ページでのタイプチェックを緩和し、複数の place_type（cafe, gift_spot 等）に対応 #51
- ルートパス (/) アクセス時に /maps へリダイレクトするよう変更 #54 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 