### PR TITLE
style: 予算表示のスタイル統一およびSpotCardアイコンの調整

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -300,12 +300,16 @@ export default function RestaurantDetailPage({ params }: Props) {
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>平均予算</div>
             <div className={styles.infoValue}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <Sun size={16} color="#efab58" />
+              <div className={styles.budgetRow}>
+                <span className={styles.budgetIcon} style={{ backgroundColor: "#efab58" }}>
+                  <Sun />
+                </span>
                 <span>{restaurant.avgLunchBudget || restaurant.averageBudget || '情報なし'}</span>
               </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '4px' }}>
-                <Moon size={16} color="#5C6BC0" />
+              <div className={styles.budgetRow}>
+                <span className={styles.budgetIcon} style={{ backgroundColor: "#5C6BC0" }}>
+                  <Moon />
+                </span>
                 <span>{restaurant.avgDinnerBudget || '情報なし'}</span>
               </div>
             </div>

--- a/miniApp/frontend/app/spots/restaurant/page.module.css
+++ b/miniApp/frontend/app/spots/restaurant/page.module.css
@@ -247,6 +247,33 @@
   line-height: 1.6;
 }
 
+.budgetRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.budgetRow + .budgetRow {
+  margin-top: 6px;
+}
+
+.budgetIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 20%;
+  color: white;
+}
+
+.budgetIcon svg {
+  stroke: white;
+  stroke-width: 2;
+  width: 60%;
+  height: 60%;
+}
+
 .link {
   color: var(--primary-color);
   text-decoration: underline;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -163,8 +163,8 @@
     align-items: center;
     justify-content: center;
 
-    width: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
-    height: clamp(1rem, 0.75rem + 2.0vw, 2.0rem);
+    width: clamp(0.875rem, 0.65rem + 1.5vw, 1.75rem);
+    height: clamp(0.875rem, 0.65rem + 1.5vw, 1.75rem);
 
     border-radius: 20%;
     color: white;
@@ -172,7 +172,7 @@
 
 .icon svg {
     stroke: white;
-    stroke-width: 3;
+    stroke-width: 2;
     width: 60%;
     height: 60%;
 }


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
予算表示のスタイル統一およびSpotCardアイコンの調整
## 変更の理由・背景

## 変更内容
- レストラン詳細ページの予算表示をCSSクラスへ移行し、アイコン背景のスタイリングを統一
- SpotCardのアイコンサイズを微調整し、SVGのストローク幅を3から2に変更 

## スクリーンショット（UI変更がある場合）
<img width="221" height="63" alt="image" src="https://github.com/user-attachments/assets/7c9d09b6-7f2b-401a-996c-bffc2dfaf005" />

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 