### PR TITLE
Refactor: next.config.ts の画像設定を remotePatterns に移行

### DIFF
--- a/miniApp/frontend/next.config.ts
+++ b/miniApp/frontend/next.config.ts
@@ -3,15 +3,14 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   images: {
-    domains: ['fukureco.jp', 'localhost'],
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: '**.fukureco.jp',
+        hostname: 'fukureco.jp',
         pathname: '/**',
       },
       {
-        protocol: 'http',
+        protocol: 'https',
         hostname: '**.fukureco.jp',
         pathname: '/**',
       },


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
next.config.ts の画像設定を remotePatterns に移行
## 変更の理由・背景
- 

## 変更内容
- 非推奨の domains オプションを削除
- fukureco.jp のホスト名指定を整理
- 全ての画像取得プロトコルを https に統一

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 