### PR TITLE
refactor: useFavoritesにおけるlineIdの初期化処理とuseEffectのロジックを改善

### DIFF
--- a/miniApp/frontend/hooks/useFavorites.ts
+++ b/miniApp/frontend/hooks/useFavorites.ts
@@ -8,24 +8,31 @@ export function useFavorites() {
   const { liff } = useLIFF();
   const [favorites, setFavorites] = useState<(number | string)[]>([]);
   const [loading, setLoading] = useState(true);
-  const [lineId, setLineId] = useState<string | null>(() => {
-    // Initial state from environment variable if available
-    if (typeof window !== "undefined") {
-      const debugId = process.env.NEXT_PUBLIC_DEBUG_LINE_ID || "GUEST_USER_ID"; // Temporary guest ID
-      console.log("Using Debug/Guest LINE ID:", debugId);
-      return debugId;
-    }
-    return null;
-  });
+  const [lineId, setLineId] = useState<string | null>(null);
 
   useEffect(() => {
-    // If we have a lineId and it's NOT the guest ID, or if liff isn't ready, skip
-    if (!liff || (lineId && lineId !== "GUEST_USER_ID" && lineId !== process.env.NEXT_PUBLIC_DEBUG_LINE_ID)) return;
+    // クライアントサイドでのみ実行される初期化
+    const debugId = process.env.NEXT_PUBLIC_DEBUG_LINE_ID || "GUEST_USER_ID";
+    
+    if (process.env.NODE_ENV !== 'production') {
+      console.log("Using Debug/Guest LINE ID:", debugId);
+    }
+    
+    setLineId(debugId);
+  }, []);
+
+  useEffect(() => {
+    // lineIdが未設定、またはLIFFが未準備なら何もしない
+    if (!liff || !lineId) return;
+
+    // すでに本物のLINE ID（デバッグ/ゲスト用以外）が設定されている場合はスキップ
+    const isTemporaryId = lineId === "GUEST_USER_ID" || lineId === process.env.NEXT_PUBLIC_DEBUG_LINE_ID;
+    if (!isTemporaryId) return;
 
     const getProfile = async () => {
       try {
         if (!liff.isLoggedIn()) {
-          // If not logged in, keep the current lineId (Guest ID)
+          // ログインしていない場合は現在のID（ゲストID）を維持
           setLoading(false);
           return;
         }

--- a/miniApp/frontend/hooks/useFavorites.ts
+++ b/miniApp/frontend/hooks/useFavorites.ts
@@ -18,7 +18,10 @@ export function useFavorites() {
       console.log("Using Debug/Guest LINE ID:", debugId);
     }
     
-    setLineId(debugId);
+    // 同期的なsetStateを避けるためマイクロタスクで実行
+    Promise.resolve().then(() => {
+      setLineId(debugId);
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION

<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
useFavoritesにおけるlineIdの初期化処理とuseEffectのロジックを改善
## 変更の理由・背景
- 

## 変更内容
- ハイドレーションエラーを防止するため、lineIdの初期化をuseStateの初期値ではなくuseEffect内で行うよう修正
- デバッグログの出力を開発環境のみに制限
- LIFFのログイン状態の判定とプロフィール取得のフローを整理し、コードの可読性を向上

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 