### PR TITLE
Fix:スポットカードが2枚左右に表示されるバグを修正しました

### DIFF
--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -406,29 +406,14 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
                       price1={spot.price1}
                       price2={spot.price2}
                       updatedAt={spot.updatedAt}
+                      isFavorite={isFavorite(spot.id)}
+                      onFavoriteToggle={() => toggleFavorite(spot.id)}
                       onCloseClick={() => {
                         setSelectedSpot(null);
                         setDisplayCards([]);
                       }}
                     />
                   )}
-                  <SpotCard
-                    spotKind={spot.spotKind}
-                    spotName={spot.spotName}
-                    isOpen={spot.isOpen}
-                    imageSrc={spot.imageSrc}
-                    spotTags={spot.spotTags}
-                    detailURL={spot.detailURL}
-                    price1={spot.price1}
-                    price2={spot.price2}
-                    updatedAt={spot.updatedAt}
-                    isFavorite={isFavorite(spot.id)}
-                    onFavoriteToggle={() => toggleFavorite(spot.id)}
-                    onCloseClick={() => {
-                      setSelectedSpot(null);
-                      setDisplayCards([]);
-                    }}
-                  />
                 </div>
               ))}
               <div className={styles.spacer} />


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
マップページで同一のスポットカードが左右に表示されるバグの修正

## 変更の理由・背景
- ローディングアニメーション追加時に、コンフリクトの解消でどちらの変更も受け入れてしまったためバグが発生した。

## 変更内容
- スポットカードが2重で表示されるバグの修正
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 