### PR TITLE
fix:スポットカードのローディングアニメーションを実際に表示されるカードの大きさに合わせました

### DIFF
--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -30,7 +30,6 @@
     }
 }
 
-/* 既存のレイアウトを流用 */
 .spotCard {
     width: 100%;
     max-width: 600px;
@@ -45,19 +44,49 @@
 
 .cardHeader {
     display: flex;
+    align-items: center;
+    padding-right: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    gap: clamp(8px, 1.5vw, 16px);
+    justify-content: space-between;
+}
+
+.titleContainer {
+    display: flex;
     flex-direction: column;
-    padding: 12px 5%;
-    gap: 8px;
+    margin-left: 5%;
+    margin-right: auto;
+    padding: 2px 0px;
+    width: 100%;
 }
 
+/* 1行の文字の高さ（line-height 1.5想定）に合わせた高さを指定 */
 .titleSkeleton {
-    width: 60%;
-    height: 28px;
+    width: 65%;
+    font-size: clamp(1.0rem, 0.25rem + 4.5vw, 2.25rem);
+    height: 1.5em; 
+    border-radius: 4px;
 }
 
-.dateSkeleton {
-    width: 30%;
-    height: 14px;
+/* 1行の文字の高さ ＋ 上下padding(2px*2) ＋ 上下border(2px*2) に合わせた高さを指定 */
+.statusSkeleton {
+    width: 65px;
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
+    height: calc(1.5em + 8px); 
+    border-radius: 10px;
+}
+
+.headerButtons {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.iconSkeleton {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
 }
 
 .cardImage {
@@ -66,42 +95,70 @@
 }
 
 .cardContents {
-    padding: 12px 7%;
+    padding: 5px 5%;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 4px clamp(10px, 1.5vw, 16px);
 }
 
 .row {
-    display: flex;
-    justify-content: space-between;
-    gap: 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    column-gap: 8px;
 }
 
-.tagsSkeleton {
+.tagsRow {
     display: flex;
-    gap: 8px;
-    flex: 1;
+    gap: clamp(6px, 1vw, 10px);
+    height: clamp(1.125rem, 0.5625rem + 2.7vw, 1.6875rem);
+    align-items: center;
 }
 
 .tagItem {
-    width: 40px;
-    height: 18px;
+    width: 50px;
+    font-size: clamp(0.75rem, 0.375rem + 1.8vw, 1.125rem);
+    height: 1.5em;
+    border-radius: 4px;
+}
+
+.pieceRange {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: clamp(6px, 1vw, 10px);
+    height: calc(clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem) * 1.5);
+}
+
+.pieceIconSkeleton {
+    width: clamp(0.875rem, 0.65rem + 1.5vw, 1.75rem);
+    height: clamp(0.875rem, 0.65rem + 1.5vw, 1.75rem);
+    border-radius: 20%;
 }
 
 .priceSkeleton {
-    width: 80px;
-    height: 24px;
+    width: 60px;
+    font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
+    height: 1.5em;
+    border-radius: 4px;
 }
 
 .cardFooter {
-    padding: 12px 5% 20px;
+    padding: 0px 5% 10px 5%;
     display: flex;
-    gap: 16px;
+    align-items: center;
+    gap: 8px;
 }
 
 .buttonSkeleton {
     flex: 1;
-    height: 40px;
+    height: clamp(34px, 8vw, 44px);
     border-radius: 9999px;
+}
+
+.heartSkeleton {
+    flex: 0 0 clamp(34px, 8vw, 44px);
+    width: clamp(34px, 8vw, 44px);
+    height: clamp(34px, 8vw, 44px);
+    border-radius: 50%;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.tsx
@@ -5,33 +5,42 @@ export const SpotCardSkeleton = () => {
     return (
         <div className={styles.spotCard}>
             <div className={styles.cardHeader}>
-                <div className={`${styles.skeleton} ${styles.titleSkeleton}`} />
-                <div className={`${styles.skeleton} ${styles.dateSkeleton}`} />
+                <div className={styles.titleContainer}>
+                    <div className={`${styles.skeleton} ${styles.titleSkeleton}`} />
+                </div>
+                <div className={`${styles.skeleton} ${styles.statusSkeleton}`} />
+                <div className={styles.headerButtons}>
+                </div>
             </div>
 
             <div className={`${styles.skeleton} ${styles.cardImage}`} />
 
             <div className={styles.cardContents}>
                 <div className={styles.row}>
-                    <div className={styles.tagsSkeleton}>
-                        <div className={`${styles.skeleton} ${styles.tagItem}`} />
+                    <div className={styles.tagsRow}>
                         <div className={`${styles.skeleton} ${styles.tagItem}`} />
                         <div className={`${styles.skeleton} ${styles.tagItem}`} />
                     </div>
-                    <div className={`${styles.skeleton} ${styles.priceSkeleton}`} />
+                    <div className={styles.pieceRange}>
+                        <div className={`${styles.skeleton} ${styles.pieceIconSkeleton}`} />
+                        <div className={`${styles.skeleton} ${styles.priceSkeleton}`} />
+                    </div>
                 </div>
                 <div className={styles.row}>
-                    <div className={styles.tagsSkeleton}>
-                        <div className={`${styles.skeleton} ${styles.tagItem}`} />
+                    <div className={styles.tagsRow}>
                         <div className={`${styles.skeleton} ${styles.tagItem}`} />
                     </div>
-                    <div className={`${styles.skeleton} ${styles.priceSkeleton}`} />
+                    <div className={styles.pieceRange}>
+                        <div className={`${styles.skeleton} ${styles.pieceIconSkeleton}`} />
+                        <div className={`${styles.skeleton} ${styles.priceSkeleton}`} />
+                    </div>
                 </div>
             </div>
 
             <div className={styles.cardFooter}>
                 <div className={`${styles.skeleton} ${styles.buttonSkeleton}`} />
                 <div className={`${styles.skeleton} ${styles.buttonSkeleton}`} />
+                <div className={`${styles.skeleton} ${styles.heartSkeleton}`} />
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポットカードのローディング時に表示していたカードのスケルトンを、実際に表示されるカードの大きさに合わせました。

## 変更の理由・背景
- ローディング時と表示カードで大きさが変わる違和感の解消

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 