### PR TITLE
fix:検索バーのテキストエリアのラベルを選択時に変更し、浮き上がらないように変更しました

### DIFF
--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
@@ -40,6 +40,26 @@
     transition: box-shadow 0.2s ease, transform 0.1s ease;
 }
 
+/* ラベルの色の調整 */
+.searchField :global(.MuiInputLabel-root) {
+    color: #999999 !important; /* 灰色に固定 */
+}
+
+/* フォーカス時のラベルの色も灰色を維持 */
+.searchField :global(.MuiInputLabel-root.Mui-focused) {
+    color: #999999 !important;
+}
+
+/* ラベルが浮き上がらない（shrink: false）際の位置調整 */
+.searchField :global(.MuiInputLabel-root) {
+    transform: translate(14px, 16px) scale(1);
+}
+
+/* 入力がある時にラベルを消すための補助設定（JS側でも空文字にしていますが念のため） */
+.searchField :global(.MuiInputLabel-root.MuiInputLabel-shrink) {
+    display: none;
+}
+
 /* ホバー時 */
 .searchButton:hover {
     background-color: rgba(0, 0, 0, 0.08);

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
@@ -16,6 +16,7 @@ type Props = {
 
 export const SearchTextField = ({ onSearch, onFocus, onBlur, label = "検索" }: Props) => {
   const [value, setValue] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
 
   const handleSearch = () => {
     if (!value.trim()) return;
@@ -23,25 +24,40 @@ export const SearchTextField = ({ onSearch, onFocus, onBlur, label = "検索" }:
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    // IME変換中のエンターキー押下（変換確定）の場合は検索を実行しない
     if (e.nativeEvent.isComposing) return;
-
     if (e.key === "Enter") {
       handleSearch();
     }
   };
 
+  const handleFocus = () => {
+    setIsFocused(true);
+    if (onFocus) onFocus();
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    if (onBlur) onBlur();
+  };
+
+  // 入力がある場合はラベルを消す。フォーカス時は専用ラベル、それ以外はデフォルトラベル。
+  const displayLabel = value !== "" ? "" : (isFocused ? "ジャンル　エリア　店名など" : label);
+
   return (
     <TextField
       fullWidth
       variant="outlined"
-      label={label}
+      label={displayLabel}
       value={value}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={handleKeyDown}
-      onFocus={onFocus}
-      onBlur={onBlur}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       className={styles.searchField}
+      // ラベルが入力文字と重ならないよう、また浮き上がらないように制御
+      InputLabelProps={{
+        shrink: false, 
+      }}
       slotProps={{
         input: {
           endAdornment: (


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
検索バーのテキストエリアのラベルを選択時に"ジャンル　エリア　店名など"に変更しました。
また、文字を入力したときにラベルが浮き上がる機能を削除しました

## 変更の理由・背景
- UX改善のため

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）
<img width="637" height="91" alt="スクリーンショット 2026-04-24 132902" src="https://github.com/user-attachments/assets/36db4970-fd1b-452e-baff-15354211c742" />

## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 