### PR TITLE
Fix:カードの店名の高さを修正しました

### DIFF
--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -65,7 +65,7 @@
 .titleSkeleton {
     width: 65%;
     font-size: clamp(1.0rem, 0.25rem + 4.5vw, 2.25rem);
-    height: 1.5em; 
+    height: 1em; 
     border-radius: 4px;
 }
 


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポットカードのローディング時と実際の表示の高さが異なっていたため修正しました。

## 変更の理由・背景
- 

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）
<img width="428" height="917" alt="スクリーンショット 2026-04-26 183112" src="https://github.com/user-attachments/assets/4083839e-5690-4325-a5e9-42b811a5743b" />
<img width="427" height="913" alt="スクリーンショット 2026-04-26 183119" src="https://github.com/user-attachments/assets/f26df174-198a-4978-8e80-5e22a4e8f55a" />


## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 