### PR TITLE
Fix:ピン押下で画面余白の中央に来るように調整しました

### DIFF
--- a/miniApp/frontend/lib/map/mapUtils.ts
+++ b/miniApp/frontend/lib/map/mapUtils.ts
@@ -1,8 +1,18 @@
-export const calculateOffsetByZoom = (zoom: number) => 0.00018 * Math.pow(2, 20 - zoom);
+/**
+ * ズームレベルに応じた緯度オフセットを計算
+ * 係数 0.00012 は、一般的なスマホ画面の高さ約10%分に相当
+ */
+export const calculateOffsetByZoom = (zoom: number) => 0.00012 * Math.pow(2, 20 - zoom);
 
+/**
+ * 指定した座標を、画面中央から10%上に表示するように地図を移動
+ */
 export const panMapToSpot = (map: google.maps.Map, position: google.maps.LatLngLiteral) => {
-  const offsetLat = calculateOffsetByZoom(map.getZoom() ?? 15);
-  map.panTo(position);
+  const zoom = map.getZoom() ?? 15;
+  const offsetLat = calculateOffsetByZoom(zoom);
+
+  // 地図の中心を「ピンの座標より少し南（下）」に設定することで、
+  //相対的にピンが「中央より北（上）」に表示されるようにする
   map.panTo({
     lat: position.lat - offsetLat,
     lng: position.lng,


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
ピン押下で、選択したピンを画面の余白の中央に来るように、オフセットを調整しました。

## 変更の理由・背景
- 

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）
<img width="410" height="896" alt="スクリーンショット 2026-04-26 183951" src="https://github.com/user-attachments/assets/5268e97f-2f20-4546-95c8-d336ef39ae92" />
<img width="372" height="666" alt="スクリーンショット 2026-04-26 184006" src="https://github.com/user-attachments/assets/277d6bbf-dd2e-4365-b2f7-558853902374" />


## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 