### PR TITLE
Tagsコンポーネントの展開時の余白を調整・うっすら見えるように変更

### DIFF
--- a/miniApp/frontend/components/atoms/tags/Tags.module.css
+++ b/miniApp/frontend/components/atoms/tags/Tags.module.css
@@ -1,25 +1,46 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
 .chips {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 0.8rem;
+  margin-bottom: 4px;
 }
 
 .chip {
   border-color: #EF633D !important;
   color: #EF633D !important;
-  background-color: rgba(239, 99, 61, 0.1) !important; /* Semi-transparent version of #EF633D */
+  background-color: rgba(239, 99, 61, 0.1) !important;
   font-weight: bold !important;
+  transition: opacity 0.3s ease !important;
 }
 
-.showMoreTags {
+.hiddenChip {
+  opacity: 0.4;
+}
+
+.showMoreButton {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
   font-size: 0.9rem;
-  font-weight:500;
+  font-weight: 500;
+  margin-top: 4px;
   margin-bottom: 1.5rem;
   cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 4px 0;
+  width: fit-content;
+  align-self: center;
 }
 
+.showMoreButton:focus-visible {
+  outline: 2px solid #EF633D;
+  border-radius: 4px;
+}

--- a/miniApp/frontend/components/atoms/tags/Tags.tsx
+++ b/miniApp/frontend/components/atoms/tags/Tags.tsx
@@ -18,33 +18,34 @@ export default function Tags ({ tags = [] }: TagsProps) {
     if (tags.length === 0) return null;
 
     return (
-       <div>
-        <div className={styles.chips} style={{ marginBottom: showAllTags ? '8px' : '0.8rem' }}>
-          {tags.slice(0, 3).map((tag, index) => (
-            <Chip key={index} label={tag} variant="outlined" size="small" className={styles.chip} />
-          ))}
-          {tags.length > 3 && !showAllTags && <div style={{ color: "#ccc", display: "flex", alignItems: "center" }}>...</div>}
-        </div>
+       <div className={styles.container}>
+        <Collapse in={showAllTags} collapsedSize={36}>
+          <div className={styles.chips}>
+            {tags.map((tag, index) => (
+              <Chip 
+                key={`${tag}-${index}`} 
+                label={tag} 
+                variant="outlined" 
+                size="small" 
+                className={`${styles.chip} ${!showAllTags && index >= 3 ? styles.hiddenChip : ''}`}
+              />
+            ))}
+          </div>
+        </Collapse>
+        
         {tags.length > 3 && (
-          <>
-            <Collapse in={showAllTags}>
-              <div className={styles.chips}>
-                {tags.slice(3).map((tag, index) => (
-                  <Chip key={index + 3} label={tag} variant="outlined" size="small" className={styles.chip} />
-                ))}
-              </div>
-            </Collapse>
-            <div 
-              className={styles.showMoreTags} 
-              onClick={() => setShowAllTags(!showAllTags)}
-            >
-              {showAllTags ? (
-                <>タグを閉じる <ChevronUp size={16} /></>
-              ) : (
-                <>タグをすべてみる <ChevronDown size={16} /></>
-              )}
-            </div>
-          </>
+          <button 
+            type="button"
+            className={styles.showMoreButton} 
+            onClick={() => setShowAllTags(!showAllTags)}
+            aria-expanded={showAllTags}
+          >
+            {showAllTags ? (
+              <>タグを閉じる <ChevronUp size={16} /></>
+            ) : (
+              <>タグをすべてみる <ChevronDown size={16} /></>
+            )}
+          </button>
         )}
        </div> 
     )

--- a/miniApp/frontend/components/atoms/tags/Tags.tsx
+++ b/miniApp/frontend/components/atoms/tags/Tags.tsx
@@ -19,7 +19,7 @@ export default function Tags ({ tags = [] }: TagsProps) {
 
     return (
        <div>
-        <div className={styles.chips}>
+        <div className={styles.chips} style={{ marginBottom: showAllTags ? '8px' : '0.8rem' }}>
           {tags.slice(0, 3).map((tag, index) => (
             <Chip key={index} label={tag} variant="outlined" size="small" className={styles.chip} />
           ))}
@@ -28,7 +28,7 @@ export default function Tags ({ tags = [] }: TagsProps) {
         {tags.length > 3 && (
           <>
             <Collapse in={showAllTags}>
-              <div className={styles.chips} style={{ marginTop: '8px' }}>
+              <div className={styles.chips}>
                 {tags.slice(3).map((tag, index) => (
                   <Chip key={index + 3} label={tag} variant="outlined" size="small" className={styles.chip} />
                 ))}


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
Tagsコンポーネントの展開時の余白を調整・うっすら見えるように変更
## 変更の理由・背景

## 変更内容
- showAllTagsの状態に応じて、1行目のチップ群の下部マージンを動的に切り替えるように変更
- 展開されるチップ群に設定されていた固定の上部マージンを削除
- Collapseコンポーネントを導入し、タグの展開・折りたたみにスムーズなアニメーションを追加
- 展開前の状態でも3つ目以降のタグを透過表示（opacity）するように変更
- 「すべてみる」ボタンをdiv要素からbutton要素に変更し、アクセシビリティを向上
- CSS Modulesのクラス名整理とフォーカス時のスタイリングを追加


## スクリーンショット（UI変更がある場合）
<img width="786" height="206" alt="image" src="https://github.com/user-attachments/assets/e7121e93-ba1b-4f3e-9a1a-c943dd011b27" />

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 