### PR TITLE
Add:next.config.tsにallowedDevOriginsを追加しngrokでのデバッグに対応

### DIFF
--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -46,9 +46,20 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   const { isFavorite, toggleFavorite } = useFavorites();
 
-  const { isLoaded } = useJsApiLoader({
+  const { isLoaded, loadError } = useJsApiLoader({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
   });
+
+  useEffect(() => {
+    console.log("Browser-side Map Load State changed:", { isLoaded, loadError });
+    if (window.google) {
+      console.log("Google object is available in window!");
+    }
+  }, [isLoaded, loadError]);
+
+  if (loadError) {
+    console.error("Google Maps API load error:", loadError);
+  }
 
   // state管理
   const [selectedSpot, setSelectedSpot] = useState<null | MapSpotData>(null);  // 選択中の詳細データ

--- a/miniApp/frontend/next.config.ts
+++ b/miniApp/frontend/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  allowedDevOrigins: [
+    ...(process.env.DEV_ALLOWED_ORIGIN ? [process.env.DEV_ALLOWED_ORIGIN] : []),
+    'localhost:3000'
+  ],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
next.configにallowedDevOriginsを追加

## 変更の理由・背景
- スマホでのデバッグを可能にするため

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- .env.localにDEV_ALLOWED_ORIGIN=”{個人のngrok固定ドメイン()}”のように設定して使用

## その他
- 