### PR TITLE
Fix: メニューで、画像がないときに、表示しないように変更

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -209,7 +209,7 @@ export default function RestaurantDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <PhotoGallery images={photoUrls} />
+      <PhotoGallery key={id} images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -209,9 +209,7 @@ export default function RestaurantDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <div className={styles.header}>
-        <PhotoGallery images={photoUrls} />
-      </div>
+      <PhotoGallery images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/restaurant/page.module.css
+++ b/miniApp/frontend/app/spots/restaurant/page.module.css
@@ -43,13 +43,6 @@
   margin: 0 auto;
 }
 
-.header {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden; /* Hide images outside the view */
-}
-
 .navIcon {
   cursor: pointer;
   filter: drop-shadow(0 0 4px rgba(0,0,0,0.5));

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -166,7 +166,7 @@ export default function RestingDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <PhotoGallery images={photoUrls} />
+      <PhotoGallery key={id} images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -166,9 +166,7 @@ export default function RestingDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <div className={styles.header}>
-        <PhotoGallery images={photoUrls} />
-      </div>
+      <PhotoGallery images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/resting/page.module.css
+++ b/miniApp/frontend/app/spots/resting/page.module.css
@@ -43,13 +43,6 @@
   margin: 0 auto;
 }
 
-.header {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-}
-
 .content {
   background-color: white;
   padding: 1rem 1.2rem;

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -186,7 +186,7 @@ export default function ShopDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <PhotoGallery images={photoUrls} />
+      <PhotoGallery key={id} images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -186,9 +186,7 @@ export default function ShopDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <div className={styles.header}>
-        <PhotoGallery images={photoUrls} />
-      </div>
+      <PhotoGallery images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/shop/page.module.css
+++ b/miniApp/frontend/app/spots/shop/page.module.css
@@ -43,13 +43,6 @@
   margin: 0 auto;
 }
 
-.header {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-}
-
 .content {
   background-color: white;
   padding: 1rem 1.2rem;

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -171,7 +171,7 @@ export default function SightseeingDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <PhotoGallery images={photoUrls} />
+      <PhotoGallery key={id} images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -171,9 +171,7 @@ export default function SightseeingDetailPage({ params }: Props) {
       </div>
 
       {/* Header Carousel */}
-      <div className={styles.header}>
-        <PhotoGallery images={photoUrls} />
-      </div>
+      <PhotoGallery images={photoUrls} />
 
       {/* Content Section */}
       <div className={styles.content}>

--- a/miniApp/frontend/app/spots/sightseeing/page.module.css
+++ b/miniApp/frontend/app/spots/sightseeing/page.module.css
@@ -43,13 +43,6 @@
   margin: 0 auto;
 }
 
-.header {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-}
-
 .content {
   background-color: white;
   padding: 1rem 1.2rem;

--- a/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
+++ b/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
@@ -13,78 +13,61 @@ type GeneralMenusProps = {
   GeneralMenus: Menu[];
 }
 
+const MenuItem = ({ item }: { item: Menu }) => {
+  const hasImage = !!item.assetId;
+  const isHttp = typeof item.assetId === 'string' && item.assetId.startsWith('http');
+
+  return (
+    <div className={styles.menuItem}>
+      {hasImage && (
+        <div className={styles.itemImage}>
+          <Image 
+            src={item.assetId!} 
+            alt={item.name} 
+            fill 
+            style={{ objectFit: 'cover' }} 
+            unoptimized={isHttp}
+          />
+        </div>
+      )}
+      <div className={styles.menuItemContent}>
+        <div className={styles.menuItemTop}>
+          <p className={styles.itemName}>{item.name}</p>
+          <div className={styles.dots}></div>
+          <p className={styles.itemPrice}>¥{item.price}</p>
+        </div>
+        <p className={styles.itemDesc}>{item.detail}</p>
+      </div>
+    </div>
+  );
+};
+
 export default function GeneralMenus({GeneralMenus}: GeneralMenusProps){
     const [showAllMenu, setShowAllMenu] = useState(false);
     return (
         <div className={styles.section}>
-       <div className={styles.menuList}>
-          {GeneralMenus.slice(0, 3).map((item, i) => (
-            <div key={i} className={styles.menuItem}>
-              <div className={styles.itemImage}>
-                {item.assetId ? (
-                  <Image 
-                    src={item.assetId} 
-                    alt={item.name} 
-                    fill 
-                    style={{ objectFit: 'cover' }} 
-                    unoptimized={item.assetId.startsWith('http')}
-                  />
-                ) : (
-                  <div className={styles.noImage}>No Image</div>
-                )}
-              </div>
-              <div className={styles.menuItemContent}>
-                <div className={styles.menuItemTop}>
-                  <p className={styles.itemName}>{item.name}</p>
-                  <div className={styles.dots}></div>
-                  <p className={styles.itemPrice}>¥{item.price}</p>
-                </div>
-                <p className={styles.itemDesc}>{item.detail}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-        <Collapse in={showAllMenu}>
-          <div className={styles.menuList} style={{ marginTop: '1rem' }}>
-            {GeneralMenus.slice(3).map((item, i) => (
-              <div key={i + 3} className={styles.menuItem}>
-                <div className={styles.itemImage}>
-                  {item.assetId ? (
-                    <Image 
-                    src={item.assetId} 
-                    alt={item.name} 
-                    fill 
-                    style={{ objectFit: 'cover' }} 
-                    unoptimized={item.assetId.startsWith('http')}
-                  />
-                  ) : (
-                    <div className={styles.noImage}>No Image</div>
-                  )}
-                </div>
-                <div className={styles.menuItemContent}>
-                  <div className={styles.menuItemTop}>
-                    <p className={styles.itemName}>{item.name}</p>
-                    <div className={styles.dots}></div>
-                    <p className={styles.itemPrice}>¥{item.price}</p>
-                  </div>
-                  <p className={styles.itemDesc}>{item.detail}</p>
-                </div>
-              </div>
+          <div className={styles.menuList}>
+            {GeneralMenus.slice(0, 3).map((item, i) => (
+              <MenuItem key={i} item={item} />
             ))}
           </div>
-        </Collapse>
-        <div 
-          className={styles.showMoreMenu} 
-          onClick={() => setShowAllMenu(!showAllMenu)}
-        >
-          {showAllMenu ? (
-            <>メニューを閉じる <ChevronUp size={18} color="#3F7D58" style={{ transform: 'translateY(2px)' }} /></>
-          ) : (
-            <>メニューをすべてみる <ChevronDown size={18} color="#3F7D58" style={{ transform: 'translateY(2px)' }} /></>
-          )}
+          <Collapse in={showAllMenu}>
+            <div className={styles.menuList} style={{ marginTop: '1rem' }}>
+              {GeneralMenus.slice(3).map((item, i) => (
+                <MenuItem key={i + 3} item={item} />
+              ))}
+            </div>
+          </Collapse>
+          <div 
+            className={styles.showMoreMenu} 
+            onClick={() => setShowAllMenu(!showAllMenu)}
+          >
+            {showAllMenu ? (
+              <>メニューを閉じる <ChevronUp size={18} color="#3F7D58" style={{ transform: 'translateY(2px)' }} /></>
+            ) : (
+              <>メニューをすべてみる <ChevronDown size={18} color="#3F7D58" style={{ transform: 'translateY(2px)' }} /></>
+            )}
+          </div>
         </div>
-      </div>
-
-
     )
 }

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -1,3 +1,10 @@
+.header {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden; /* Hide images outside the view */
+}
+
 .galleryContainer{
     position: relative; /* 子要素の absolute 配置の基準にする */
     width: 100%;

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import styles from "./PhotoGallery.module.css";
 import Image from "next/image";
 import {
@@ -12,22 +12,13 @@ interface PhotoGalleryProps {
 }
 
 export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
-    if (!images || images.length === 0) {
-        return null;
-    }
-
-    const headerImages = images;
+    const headerImages = images || [];
     const [currentImgIndex, setCurrentImgIndex] = useState(0);
     const [touchStart, setTouchStart] = useState<number | null>(null);
     const [touchEnd, setTouchEnd] = useState<number | null>(null);
 
     // スワイプの最小距離（px）
     const minSwipeDistance = 50;
-
-    // 画像リストが変わった際にインデックスをリセットする
-    useEffect(() => {
-        setCurrentImgIndex(0);
-    }, [images]);
 
     const nextImage = useCallback(() => {
         if (headerImages.length <= 1) return;
@@ -77,6 +68,10 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
 
         return () => clearInterval(interval);
     }, [nextImage, headerImages.length]);
+
+    if (headerImages.length === 0) {
+        return null;
+    }
 
     return(
         <div className={styles.header}>

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import styles from "./PhotoGallery.module.css";
 import Image from "next/image";
 import {
@@ -12,27 +12,22 @@ interface PhotoGalleryProps {
 }
 
 export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
-    const headerImages = useMemo(() => {
-        return images && images.length > 0 ? images : [
-            "/ramen.jpg",
-            "/tonkotsu.jpg",
-            "/ramen.jpg", // 仮の3枚目
-        ];
-    }, [images]);
-
-    const [currentImgIndex, setCurrentImgIndex] = useState(0);
-
-    // 画像リストが変わった際にインデックスをリセットする
-    const [prevImages, setPrevImages] = useState(headerImages);
-    if (headerImages !== prevImages) {
-        setPrevImages(headerImages);
-        setCurrentImgIndex(0);
+    if (!images || images.length === 0) {
+        return null;
     }
+
+    const headerImages = images;
+    const [currentImgIndex, setCurrentImgIndex] = useState(0);
     const [touchStart, setTouchStart] = useState<number | null>(null);
     const [touchEnd, setTouchEnd] = useState<number | null>(null);
 
     // スワイプの最小距離（px）
     const minSwipeDistance = 50;
+
+    // 画像リストが変わった際にインデックスをリセットする
+    useEffect(() => {
+        setCurrentImgIndex(0);
+    }, [images]);
 
     const nextImage = useCallback(() => {
         if (headerImages.length <= 1) return;
@@ -78,57 +73,59 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
 
         const interval = setInterval(() => {
             nextImage();
-        }, 5000); // 5秒ごとにスライド
+        }, 5000);
 
         return () => clearInterval(interval);
     }, [nextImage, headerImages.length]);
 
     return(
-        <div 
-            className={styles.galleryContainer}
-            onTouchStart={onTouchStart}
-            onTouchMove={onTouchMove}
-            onTouchEnd={onTouchEnd}
-        >
+        <div className={styles.header}>
             <div 
-          className={styles.imageTrack} 
-          style={{ transform: `translateX(-${currentImgIndex * 100}%)` }}
-        >
-          {headerImages.map((src, index) => (
-            <div key={index} className={styles.imageContainer}>
-              {isVideo(src) ? (
-                  <video 
-                    src={src} 
-                    className={styles.mainVideo} 
-                    autoPlay 
-                    muted 
-                    loop 
-                    playsInline 
-                  />
-              ) : (
-                <Image
-                    src={src}
-                    alt={`Restaurant Media ${index}`}
-                    fill
-                    className={styles.mainImage}
-                    priority={index === 0}
-                    unoptimized={src.startsWith('http')}
-                />
-              )}
+                className={styles.galleryContainer}
+                onTouchStart={onTouchStart}
+                onTouchMove={onTouchMove}
+                onTouchEnd={onTouchEnd}
+            >
+                <div 
+                    className={styles.imageTrack} 
+                    style={{ transform: `translateX(-${currentImgIndex * 100}%)` }}
+                >
+                {headerImages.map((src, index) => (
+                    <div key={index} className={styles.imageContainer}>
+                    {isVideo(src) ? (
+                        <video 
+                            src={src} 
+                            className={styles.mainVideo} 
+                            autoPlay 
+                            muted 
+                            loop 
+                            playsInline 
+                        />
+                    ) : (
+                        <Image
+                            src={src}
+                            alt={`Spot Media ${index}`}
+                            fill
+                            className={styles.mainImage}
+                            priority={index === 0}
+                            unoptimized={src.startsWith('http')}
+                        />
+                    )}
+                    </div>
+                ))}
+                </div>
+                {headerImages.length > 1 && (
+                <>
+                    <div className={styles.carouselNav}>
+                    <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} />
+                    <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} />
+                    </div>
+                    <div className={styles.carouselIndicator}>
+                    {currentImgIndex + 1}/{headerImages.length}
+                    </div>
+                </>
+                )}
             </div>
-          ))}
-        </div>
-        {headerImages.length > 1 && (
-          <>
-            <div className={styles.carouselNav}>
-              <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} />
-              <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} />
-            </div>
-            <div className={styles.carouselIndicator}>
-              {currentImgIndex + 1}/{headerImages.length}
-            </div>
-          </>
-        )}
         </div>
     )
 }

--- a/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
+++ b/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
@@ -7,26 +7,27 @@ type recommendMenuProps = {
 } 
 
 export default function RecommendMenu ({ recommendMenu }: recommendMenuProps) {
- return (
-    <div className={styles.recommendedItem}>
-        <div className={styles.itemImage}>
-            {recommendMenu.assetId ? (
-                <Image 
-                    src={recommendMenu.assetId} 
-                    alt={recommendMenu.name} 
-                    fill 
-                    style={{ objectFit: 'cover' }}
-                    unoptimized={recommendMenu.assetId.startsWith('http')}
-                />
-            ) : (
-                <div className={styles.noImage}>No Image</div>
+    const hasImage = !!recommendMenu.assetId;
+    const isHttp = typeof recommendMenu.assetId === 'string' && recommendMenu.assetId.startsWith('http');
+
+    return (
+        <div className={styles.recommendedItem}>
+            {hasImage && (
+                <div className={styles.itemImage}>
+                    <Image 
+                        src={recommendMenu.assetId!} 
+                        alt={recommendMenu.name} 
+                        fill 
+                        style={{ objectFit: 'cover' }}
+                        unoptimized={isHttp}
+                    />
+                </div>
             )}
+            <div className={styles.itemInfo}>
+                <p className={styles.itemName}>{recommendMenu.name}</p>
+                <p className={styles.itemDesc}>{recommendMenu.detail}</p>
+                <p className={styles.itemPrice}>¥{recommendMenu.price}</p>
+            </div>
         </div>
-        <div className={styles.itemInfo}>
-            <p className={styles.itemName}>{recommendMenu.name}</p>
-            <p className={styles.itemDesc}>{recommendMenu.detail}</p>
-            <p className={styles.itemPrice}>¥{recommendMenu.price}</p>
-        </div>
-    </div>
- )
+    )
 }


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
メニューで画像がないときに、表示しないように変更

## 変更内容
- 各スポット詳細ページに重複していたヘッダー用スタイルをPhotoGalleryコンポーネント内に移動し、カプセル化を強化
- GeneralMenusコンポーネント内の繰り返し処理をMenuItemサブコンポーネントとして抽出し、コードの再利用性を向上
- PhotoGalleryにおける画像切り替え時のインデックスリセット処理をuseEffectによる実装に改善
- 各コンポーネントでの画像表示ロジックを簡素化し、条件分岐を整理
 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 