### PR TITLE
feat: PhotoGalleryに無限ループ機能を実装、フォトギャラリーのUI改善、インジケーターのドット表示化

### DIFF
--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -15,21 +15,26 @@
   display: flex;
   width: 100%;
   height: 100%;
-  transition: transform 0.5s ease-in-out; /* Smooth sliding */
 }
 
 .imageContainer {
   position: relative;
   min-width: 100%;
-  flex-shrink: 0; /* 追加: フレックスボックス内で画像が縮まないようにする */
+  flex-shrink: 0;
   height: 100%;
+  background-color: #1e1e1e; /* 背景を濃いグレーに変更 */
 }
 
-.mainImage,
-.mainVideo {
+.mainImage {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.mainVideo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain; /* 動画は全体が見えるように contain に変更 */
 }
 
 .carouselNav {

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -35,21 +35,71 @@
 .carouselNav {
   position: absolute;
   top: 50%;
+  left: 0;
   width: 100%;
   display: flex;
   justify-content: space-between;
   padding: 0 10px;
   transform: translateY(-50%);
-  color: white;
+  pointer-events: none; /* 下の画像へのタッチイベントを邪魔しないように（アイコン以外） */
+}
+
+.navIcon {
+  cursor: pointer;
+  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.5)); /* 暗い背景でも見やすいように影を追加 */
+  color: #FFFFFF;
+  transition: opacity 0.2s ease;
+  pointer-events: auto; /* アイコン自体はクリック可能にする */
+}
+
+.navIcon:hover {
+  opacity: 0.8;
+}
+
+.navIcon:active {
+  opacity: 0.5;
 }
 
 .carouselIndicator {
   position: absolute;
   bottom: 10px;
-  right: 10px;
-  background-color: rgba(0, 0, 0, 0.5);
-  color: white;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 6px;
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 4px 10px;
+  border-radius: 20px;
+  backdrop-filter: blur(2px);
+  align-items: center;
+  justify-content: center;
+  min-width: 60px; /* 5ドットに合わせて少し広げる */
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  transition: background-color 0.3s ease, transform 0.3s ease, opacity 0.3s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+  transform: scale(1);
+}
+
+.dot.smallDot {
+  transform: scale(0.6);
+  opacity: 0.6;
+}
+
+.dot.activeDot {
+  background-color: white;
+  transform: scale(1.2);
+  opacity: 1;
+}
+
+/* 端にあるがアクティブな場合の表示（詳細度をさらに上げる） */
+.dot.activeDot.smallDot {
+  transform: scale(1);
+  opacity: 1;
 }

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import styles from "./PhotoGallery.module.css";
 import Image from "next/image";
 import {
@@ -58,16 +58,19 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
         return videoExtensions.some(ext => url.toLowerCase().endsWith(ext));
     };
 
-    // 自動スライドの設定
-    useEffect(() => {
-        if (headerImages.length <= 1) return;
+    // 表示するドットの範囲を計算（最大5個）
+    const getVisibleDotIndices = () => {
+        const maxVisible = 5;
+        if (headerImages.length <= maxVisible) return headerImages.map((_, i) => i);
+        
+        let start = Math.max(0, currentImgIndex - 2);
+        if (start + maxVisible > headerImages.length) {
+            start = headerImages.length - maxVisible;
+        }
+        return Array.from({ length: maxVisible }, (_, i) => start + i);
+    };
 
-        const interval = setInterval(() => {
-            nextImage();
-        }, 5000);
-
-        return () => clearInterval(interval);
-    }, [nextImage, headerImages.length]);
+    const visibleDotIndices = getVisibleDotIndices();
 
     if (headerImages.length === 0) {
         return null;
@@ -112,11 +115,33 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
                 {headerImages.length > 1 && (
                 <>
                     <div className={styles.carouselNav}>
-                    <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} />
-                    <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} />
+                    <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} aria-label="前の画像へ" />
+                    <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} aria-label="次の画像へ" />
                     </div>
-                    <div className={styles.carouselIndicator}>
-                    {currentImgIndex + 1}/{headerImages.length}
+                    <div 
+                        className={styles.carouselIndicator} 
+                        role="group" 
+                        aria-label="画像スライダーの進捗"
+                    >
+                    {visibleDotIndices.map((index, idx) => {
+                        const isActive = index === currentImgIndex;
+                        const isFirst = idx === 0;
+                        const isLast = idx === visibleDotIndices.length - 1;
+                        const hasMorePrev = isFirst && index > 0;
+                        const hasMoreNext = isLast && index < headerImages.length - 1;
+
+                        return (
+                            <div 
+                                key={index} 
+                                className={`
+                                    ${styles.dot} 
+                                    ${isActive ? styles.activeDot : ""} 
+                                    ${hasMorePrev || hasMoreNext ? styles.smallDot : ""}
+                                `}
+                                aria-current={isActive ? "true" : "false"}
+                            />
+                        );
+                    })}
                     </div>
                 </>
                 )}

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
@@ -13,7 +13,13 @@ interface PhotoGalleryProps {
 
 export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
     const headerImages = images || [];
-    const [currentImgIndex, setCurrentImgIndex] = useState(0);
+    // クローンを追加した画像リストを作成
+    const extendedImages = headerImages.length > 1 
+        ? [headerImages[headerImages.length - 1], ...headerImages, headerImages[0]]
+        : headerImages;
+
+    const [currentImgIndex, setCurrentImgIndex] = useState(headerImages.length > 1 ? 1 : 0);
+    const [isTransitioning, setIsTransitioning] = useState(false);
     const [touchStart, setTouchStart] = useState<number | null>(null);
     const [touchEnd, setTouchEnd] = useState<number | null>(null);
 
@@ -21,14 +27,39 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
     const minSwipeDistance = 50;
 
     const nextImage = useCallback(() => {
-        if (headerImages.length <= 1) return;
-        setCurrentImgIndex((prev) => (prev + 1) % headerImages.length);
-    }, [headerImages.length]);
+        if (headerImages.length <= 1 || isTransitioning) return;
+        setIsTransitioning(true);
+        setCurrentImgIndex((prev) => prev + 1);
+    }, [headerImages.length, isTransitioning]);
 
     const prevImage = useCallback(() => {
+        if (headerImages.length <= 1 || isTransitioning) return;
+        setIsTransitioning(true);
+        setCurrentImgIndex((prev) => prev - 1);
+    }, [headerImages.length, isTransitioning]);
+
+    const handleTransitionEnd = () => {
+        setIsTransitioning(false);
         if (headerImages.length <= 1) return;
-        setCurrentImgIndex((prev) => (prev - 1 + headerImages.length) % headerImages.length);
-    }, [headerImages.length]);
+
+        // クローンに到達した瞬間に、アニメーションなしで本物の位置へワープする
+        if (currentImgIndex === 0) {
+            // 先頭のクローン（最後の画像）にいる場合 -> 本物の最後へ
+            setCurrentImgIndex(headerImages.length);
+        } else if (currentImgIndex === headerImages.length + 1) {
+            // 末尾のクローン（最初の画像）にいる場合 -> 本物の最初へ
+            setCurrentImgIndex(1);
+        }
+    };
+
+    // インジケーター用の現在のアクティブなインデックス
+    const activeDotIndex = headerImages.length > 1 
+        ? (currentImgIndex === 0 
+            ? headerImages.length - 1 
+            : currentImgIndex === headerImages.length + 1 
+                ? 0 
+                : currentImgIndex - 1)
+        : 0;
 
     const onTouchStart = (e: React.TouchEvent) => {
         setTouchEnd(null);
@@ -63,7 +94,7 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
         const maxVisible = 5;
         if (headerImages.length <= maxVisible) return headerImages.map((_, i) => i);
         
-        let start = Math.max(0, currentImgIndex - 2);
+        let start = Math.max(0, activeDotIndex - 2);
         if (start + maxVisible > headerImages.length) {
             start = headerImages.length - maxVisible;
         }
@@ -86,9 +117,13 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
             >
                 <div 
                     className={styles.imageTrack} 
-                    style={{ transform: `translateX(-${currentImgIndex * 100}%)` }}
+                    style={{ 
+                        transform: `translateX(-${currentImgIndex * 100}%)`,
+                        transition: isTransitioning ? 'transform 0.5s ease-in-out' : 'none'
+                    }}
+                    onTransitionEnd={handleTransitionEnd}
                 >
-                {headerImages.map((src, index) => (
+                {extendedImages.map((src, index) => (
                     <div key={index} className={styles.imageContainer}>
                     {isVideo(src) ? (
                         <video 
@@ -105,7 +140,7 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
                             alt={`Spot Media ${index}`}
                             fill
                             className={styles.mainImage}
-                            priority={index === 0}
+                            priority={index === 1} // 本物の最初の画像にpriorityをつける
                             unoptimized={src.startsWith('http')}
                         />
                     )}
@@ -124,7 +159,7 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
                         aria-label="画像スライダーの進捗"
                     >
                     {visibleDotIndices.map((index, idx) => {
-                        const isActive = index === currentImgIndex;
+                        const isActive = index === activeDotIndex;
                         const isFirst = idx === 0;
                         const isLast = idx === visibleDotIndices.length - 1;
                         const hasMorePrev = isFirst && index > 0;


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要


## 変更内容
- インジケーターを従来の数字表示から、最大5個表示の動的なドット形式に変更
- ユーザー体験向上のため、画像の自動スライド機能を削除
- ナビゲーションアイコンの視認性向上（ドロップシャドウ追加）とインタラクションを改善
- ナビゲーションエリアのタッチイベントを透過させ、画像操作を妨げないよう調整
- アクセシビリティ向上のため aria-label 等の属性を追加
- 画像リストの両端にクローンを追加し、シームレスな無限スクロールを実現
- onTransitionEnd を用いた位置リセット処理の実装
- 動画の表示スタイルを object-fit: contain に変更し、背景色を設定
- アニメーション中の重複操作を防止する isTransitioning 状態を追加

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 