### PR TITLE
fix:IOSで店名や価格帯の文字を明朝体からゴシック体に修正しました

### DIFF
--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -2,6 +2,8 @@ html,
 body {
   padding: 0;
   margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+  color: var(--text-black);
 }
 
 a {

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -11,14 +11,6 @@
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
     display: flex;
     flex-direction: column;
-
-    /* global.cssに統合 */
-    font-family:
-        "Hiragino Kaku Gothic ProN",
-        "Hiragino Sans",
-        "Yu Gothic",
-        "Meiryo",
-        "Noto Sans JP", ;
 }
 
 
@@ -152,9 +144,6 @@
     font-size: clamp(0.875rem, 0.375rem + 2.5vw, 1.375rem);
     font-weight: 600;
     color: #2f4f3f;
-    font-family:
-        "Yu Gothic";
-        
 }
 
 /* アイコン丸背景 */


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
iphoneでマップページのスポットカードの店名と価格帯をゴシック体に修正

## 変更の理由・背景
- 一部が明朝体になっていたため。

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 