### PR TITLE
Fix: Spotsの基本情報に関するバグを修正しました

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -248,7 +248,16 @@ export default function RestaurantDetailPage({ params }: Props) {
                 </>
               )
             },
-            { label: "支払方法", value: restaurant.paymentMethods || "情報なし" },
+            { 
+              label: "支払方法", 
+              value: Array.isArray(restaurant.paymentMethods) ? (
+                restaurant.paymentMethods.map((method, idx) => (
+                  <div key={idx}>{method}</div>
+                ))
+              ) : (
+                restaurant.paymentMethods || "情報なし"
+              )
+            },
             { label: "駐車場", value: restaurant.parkingInfo || "情報なし" },
             { 
               label: "ウェブサイト", 
@@ -256,6 +265,7 @@ export default function RestaurantDetailPage({ params }: Props) {
                 <InfoLink href={restaurant.websiteUrl}>{restaurant.websiteUrl}</InfoLink>
               ) : "情報なし"
             },
+            { label: "施設コメント", value: restaurant.restaurantComment || "無し" },
             { label: "備考", value: restaurant.remarks || "無し" },
           ]}
         />

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -23,7 +23,7 @@ import { useFavorites } from '@/hooks/useFavorites';
 import { SpotDetailSkeleton } from '@/components/atoms/spotCard/SpotDetailSkeleton';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink, BudgetRow } from "@/components/atoms/spotInfoTable/SpotInfoTable";
-import { mapToRestaurant } from "@/lib/spot-mapper";
+import { mapToRestaurant, RawRestaurant } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -113,7 +113,7 @@ export default function RestaurantDetailPage({ params }: Props) {
     return <SpotDetailSkeleton />;
   }
 
-  const spot = mapToRestaurant(spotData);
+  const spot = mapToRestaurant(spotData as unknown as RawRestaurant);
 
   const assetMap = (assetData as unknown as { id: number, url: string }[]).reduce((acc, asset) => {
     acc[asset.id] = asset.url;

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -23,6 +23,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import { SpotDetailSkeleton } from '@/components/atoms/spotCard/SpotDetailSkeleton';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
+import { SpotInfoTable, InfoLink, BudgetRow } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -283,70 +284,40 @@ export default function RestaurantDetailPage({ params }: Props) {
           <div className={styles.sectionBar}></div>
           <h2 className={styles.sectionTitle}>基本情報</h2>
         </div>
-        <div className={styles.infoTable}>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>住所</div>
-            <div className={styles.infoValue}>{restaurant.address}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>営業時間</div>
-            <div className={styles.infoValue}>{restaurant.businessHours || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>電話番号</div>
-            <div className={styles.infoValue}>{restaurant.phoneNumber || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>定休日</div>
-            <div className={styles.infoValue}>{restaurant.closedDays || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>平均予算</div>
-            <div className={styles.infoValue}>
-              <div className={styles.budgetRow}>
-                <span className={styles.budgetIcon} style={{ backgroundColor: "#efab58" }}>
-                  <Sun />
-                </span>
-                <span>{restaurant.avgLunchBudget || restaurant.averageBudget || '情報なし'}</span>
-              </div>
-              <div className={styles.budgetRow}>
-                <span className={styles.budgetIcon} style={{ backgroundColor: "#5C6BC0" }}>
-                  <Moon />
-                </span>
-                <span>{restaurant.avgDinnerBudget || '情報なし'}</span>
-              </div>
-            </div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>支払方法</div>
-            <div className={styles.infoValue}>{restaurant.paymentMethods || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>駐車場</div>
-            <div className={styles.infoValue}>{restaurant.parkingInfo || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>ウェブサイト</div>
-            <div className={styles.infoValue}>
-              {restaurant.websiteUrl ? (
-                <a 
-                  href={restaurant.websiteUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className={styles.link}
-                >
-                  {restaurant.websiteUrl}
-                </a>
-              ) : (
-                "情報なし"
-              )}
-            </div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>備考</div>
-            <div className={styles.infoValue}>{restaurant.remarks || "無し"}</div>
-          </div>
-        </div>
+        <SpotInfoTable 
+          items={[
+            { label: "住所", value: restaurant.address },
+            { label: "営業時間", value: restaurant.businessHours || '情報なし' },
+            { label: "電話番号", value: restaurant.phoneNumber || '情報なし' },
+            { label: "定休日", value: restaurant.closedDays || "情報なし" },
+            { 
+              label: "平均予算", 
+              value: (
+                <>
+                  <BudgetRow 
+                    icon={<Sun />} 
+                    iconBgColor="#efab58" 
+                    label={restaurant.avgLunchBudget || restaurant.averageBudget || '情報なし'} 
+                  />
+                  <BudgetRow 
+                    icon={<Moon />} 
+                    iconBgColor="#5C6BC0" 
+                    label={restaurant.avgDinnerBudget || '情報なし'} 
+                  />
+                </>
+              )
+            },
+            { label: "支払方法", value: restaurant.paymentMethods || "情報なし" },
+            { label: "駐車場", value: restaurant.parkingInfo || "情報なし" },
+            { 
+              label: "ウェブサイト", 
+              value: restaurant.websiteUrl ? (
+                <InfoLink href={restaurant.websiteUrl}>{restaurant.websiteUrl}</InfoLink>
+              ) : "情報なし"
+            },
+            { label: "備考", value: restaurant.remarks || "無し" },
+          ]}
+        />
       </div>
 
       {/* Nearby Spots Section */}

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -13,7 +13,6 @@ import {
   Sun,
   Moon,
 } from "lucide-react";
-import { Restaurant } from '@/types/spot'
 import { Menu } from '@/types/menu'
 
 import RecommendMenu from "@/components/atoms/recommendMenu/RecommendMenu";
@@ -24,6 +23,7 @@ import { useFavorites } from '@/hooks/useFavorites';
 import { SpotDetailSkeleton } from '@/components/atoms/spotCard/SpotDetailSkeleton';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink, BudgetRow } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { mapToRestaurant } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -113,66 +113,7 @@ export default function RestaurantDetailPage({ params }: Props) {
     return <SpotDetailSkeleton />;
   }
 
-  // Cast dynamic data to internal interfaces for property access
-  const spot = spotData as unknown as {
-    id: number;
-    name: string;
-    catchphrase?: string;
-    distance_from_transit?: string;
-    stay_duration?: string;
-    fukureko_comment?: string;
-    address: string;
-    business_hours?: string;
-    phone_number?: string;
-    nearest_station?: string;
-    website_url?: string;
-    average_budget?: string | number;
-    place_type: string;
-    pricing?: Record<string, unknown>;
-    facilities?: Record<string, unknown>;
-    updated_at: string;
-    created_at: string;
-    nearby_coin_lockers?: string;
-    parking_info?: string;
-    payment_methods?: string[];
-    closed_days?: string;
-    reservation_url?: string;
-    remarks?: string;
-    avg_lunch_budget?: string;
-    avg_dinner_budget?: string;
-    latitude: string;
-    longitude: string;
-  };
-
-  const restaurant: Restaurant = {
-    id: spot.id,
-    name: spot.name,
-    catchphrase: spot.catchphrase,
-    distanceFromTransit: spot.distance_from_transit,
-    stayDuration: spot.stay_duration,
-    fukurekoComment: spot.fukureko_comment,
-    address: spot.address,
-    businessHours: spot.business_hours,
-    phoneNumber: spot.phone_number,
-    nearestStation: spot.nearest_station,
-    websiteUrl: spot.website_url,
-    averageBudget: spot.average_budget,
-    placeType: spot.place_type,
-    pricing: spot.pricing || {},
-    facilities: spot.facilities || {},
-    updatedAt: new Date(spot.updated_at),
-    createdAt: new Date(spot.created_at),
-    nearbyCoinLockers: spot.nearby_coin_lockers,
-    parkingInfo: spot.parking_info,
-    paymentMethods: spot.payment_methods,
-    closedDays: spot.closed_days,
-    reservationURL: spot.reservation_url,
-    remarks: spot.remarks,
-    avgLunchBudget: spot.avg_lunch_budget,
-    avgDinnerBudget: spot.avg_dinner_budget,
-    latitude: parseFloat(spot.latitude),
-    longitude: parseFloat(spot.longitude),
-  };
+  const restaurant = mapToRestaurant(spotData);
 
   const assetMap = (assetData as unknown as { id: number, url: string }[]).reduce((acc, asset) => {
     acc[asset.id] = asset.url;
@@ -287,8 +228,8 @@ export default function RestaurantDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: restaurant.address },
-            { label: "営業時間", value: restaurant.businessHours || '情報なし' },
-            { label: "電話番号", value: restaurant.phoneNumber || '情報なし' },
+            { label: "営業時間", value: restaurant.businessHours || "情報なし" },
+            { label: "電話番号", value: restaurant.phoneNumber || "情報なし" },
             { label: "定休日", value: restaurant.closedDays || "情報なし" },
             { 
               label: "平均予算", 
@@ -297,12 +238,12 @@ export default function RestaurantDetailPage({ params }: Props) {
                   <BudgetRow 
                     icon={<Sun />} 
                     iconBgColor="#efab58" 
-                    label={restaurant.avgLunchBudget || restaurant.averageBudget || '情報なし'} 
+                    label={restaurant.avgLunchBudget || restaurant.averageBudget || "情報なし"} 
                   />
                   <BudgetRow 
                     icon={<Moon />} 
                     iconBgColor="#5C6BC0" 
-                    label={restaurant.avgDinnerBudget || '情報なし'} 
+                    label={restaurant.avgDinnerBudget || "情報なし"} 
                   />
                 </>
               )

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -113,7 +113,7 @@ export default function RestaurantDetailPage({ params }: Props) {
     return <SpotDetailSkeleton />;
   }
 
-  const restaurant = mapToRestaurant(spotData);
+  const spot = mapToRestaurant(spotData);
 
   const assetMap = (assetData as unknown as { id: number, url: string }[]).reduce((acc, asset) => {
     acc[asset.id] = asset.url;
@@ -155,10 +155,10 @@ export default function RestaurantDetailPage({ params }: Props) {
 
       {/* Content Section */}
       <div className={styles.content}>
-        <p className={styles.catchphrase}>{restaurant.catchphrase}</p>
-        <h1 className={styles.title}>{restaurant.name}</h1>
+        <p className={styles.catchphrase}>{spot.catchphrase}</p>
+        <h1 className={styles.title}>{spot.name}</h1>
         <div className={styles.updatedAt}>
-          更新日: {restaurant.updatedAt.toLocaleDateString('ja-JP')}
+          更新日: {spot.updatedAt.toLocaleDateString('ja-JP')}
         </div>
         <Tags tags={tagData} />
       </div>
@@ -171,20 +171,20 @@ export default function RestaurantDetailPage({ params }: Props) {
         </div>
         <div className={styles.safetyCard}>
           <p className={styles.safetyLabel}>最寄り駅/バス停</p>
-          <p className={styles.safetyValue}>{restaurant.nearestStation || '情報なし'}</p>
+          <p className={styles.safetyValue}>{spot.nearestStation || '情報なし'}</p>
         </div>
         <div className={styles.safetyCard}>
           <p className={styles.safetyLabel}>空港・駅から（最短）</p>
-          <p className={styles.safetyValue}>{restaurant.distanceFromTransit || '情報なし'}</p>
+          <p className={styles.safetyValue}>{spot.distanceFromTransit || '情報なし'}</p>
         </div>
         <div className={styles.safetyGrid}>
           <div className={styles.safetyCard}>
             <p className={styles.safetyLabel}>滞在目安</p>
-            <p className={styles.safetyValue}>{restaurant.stayDuration || '情報なし'}</p>
+            <p className={styles.safetyValue}>{spot.stayDuration || '情報なし'}</p>
           </div>
           <div className={styles.safetyCard}>
             <p className={styles.safetyLabel}>近くのコインロッカー</p>
-            <p className={styles.safetyValue}>{restaurant.nearbyCoinLockers || '情報なし'}</p>
+            <p className={styles.safetyValue}>{spot.nearbyCoinLockers || '情報なし'}</p>
           </div>
         </div>
       </div>
@@ -214,7 +214,7 @@ export default function RestaurantDetailPage({ params }: Props) {
           <p className={styles.noData}>メニューはまだ登録されていません。</p>
         )}
         <div className={styles.staffComment}>
-          <p className={styles.commentText}>{restaurant.fukurekoComment}</p>
+          <p className={styles.commentText}>{spot.fukurekoComment}</p>
           <p className={styles.commentAuthor}>— フクレコ運営スタッフ</p>
         </div>
       </div>
@@ -227,10 +227,10 @@ export default function RestaurantDetailPage({ params }: Props) {
         </div>
         <SpotInfoTable 
           items={[
-            { label: "住所", value: restaurant.address },
-            { label: "営業時間", value: restaurant.businessHours || "情報なし" },
-            { label: "電話番号", value: restaurant.phoneNumber || "情報なし" },
-            { label: "定休日", value: restaurant.closedDays || "情報なし" },
+            { label: "住所", value: spot.address },
+            { label: "営業時間", value: spot.businessHours },
+            { label: "電話番号", value: spot.phoneNumber },
+            { label: "定休日", value: spot.closedDays },
             { 
               label: "平均予算", 
               value: (
@@ -238,62 +238,51 @@ export default function RestaurantDetailPage({ params }: Props) {
                   <BudgetRow 
                     icon={<Sun />} 
                     iconBgColor="#efab58" 
-                    label={restaurant.avgLunchBudget || restaurant.averageBudget || "情報なし"} 
+                    label={spot.avgLunchBudget || spot.averageBudget} 
                   />
                   <BudgetRow 
                     icon={<Moon />} 
                     iconBgColor="#5C6BC0" 
-                    label={restaurant.avgDinnerBudget || "情報なし"} 
+                    label={spot.avgDinnerBudget} 
                   />
                 </>
               )
             },
-            { 
-              label: "支払方法", 
-              value: Array.isArray(restaurant.paymentMethods) ? (
-                restaurant.paymentMethods.map((method, idx) => (
-                  <div key={idx}>{method}</div>
-                ))
-              ) : (
-                restaurant.paymentMethods || "情報なし"
-              )
-            },
-            { label: "駐車場", value: restaurant.parkingInfo || "情報なし" },
+            { label: "支払方法", value: spot.paymentMethods },
+            { label: "駐車場", value: spot.parkingInfo },
             { 
               label: "ウェブサイト", 
-              value: restaurant.websiteUrl ? (
-                <InfoLink href={restaurant.websiteUrl}>{restaurant.websiteUrl}</InfoLink>
-              ) : "情報なし"
+              value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "施設コメント", value: restaurant.restaurantComment || "無し" },
-            { label: "備考", value: restaurant.remarks || "無し" },
+            { label: "スポットコメント", value: spot.restaurantComment },
+            { label: "備考", value: spot.remarks },
           ]}
         />
       </div>
 
       {/* Nearby Spots Section */}
-      {typeof restaurant.latitude === 'number' && typeof restaurant.longitude === 'number' && !isNaN(restaurant.latitude) && !isNaN(restaurant.longitude) && (
+      {typeof spot.latitude === 'number' && typeof spot.longitude === 'number' && !isNaN(spot.latitude) && !isNaN(spot.longitude) && (
         <NearbySpots 
-          lat={restaurant.latitude} 
-          lng={restaurant.longitude} 
-          currentId={restaurant.id} 
+          lat={spot.latitude} 
+          lng={spot.longitude} 
+          currentId={spot.id} 
         />
       )}
 
       {/* Action Footer */}
       <div className={styles.actionFooter}>
-        {restaurant.reservationURL ? (
+        {spot.reservationURL ? (
           <a 
-            href={restaurant.reservationURL}
+            href={spot.reservationURL}
             target="_blank"
             rel="noopener noreferrer"
             className={btnStyles.reserveBtn}
           >
             予約する
           </a>
-        ) : restaurant.phoneNumber ? (
+        ) : spot.phoneNumber ? (
           <a 
-            href={`tel:${restaurant.phoneNumber}`}
+            href={`tel:${spot.phoneNumber}`}
             className={btnStyles.reserveBtn}
           >
             電話する
@@ -304,7 +293,7 @@ export default function RestaurantDetailPage({ params }: Props) {
           </button>
         )}
         <a 
-          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${restaurant.name} ${restaurant.address}`)}`}
+          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
           target="_blank"
           rel="noopener noreferrer"
           className={btnStyles.routeBtn}

--- a/miniApp/frontend/app/spots/restaurant/page.module.css
+++ b/miniApp/frontend/app/spots/restaurant/page.module.css
@@ -210,69 +210,6 @@
   color: #666;
 }
 
-.infoTable {
-  width: 100%;
-  background-color: #f5f5f5; /* Light gray background for the whole box */
-  border-radius: 12px;
-  overflow: hidden; /* Ensures rows don't overlap rounded corners */
-}
-
-.infoRow {
-  display: flex;
-  padding: 0.8rem;
-  border-bottom: 1px solid white; /* White separator line */
-}
-
-.infoRow:last-child {
-  border-bottom: none;
-}
-
-.infoLabel {
-  width: 90px;
-  font-weight: bold;
-  font-size: 0.9rem;
-  color: var(--text-black);
-}
-
-.infoValue {
-  flex: 1;
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-
-.budgetRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.budgetRow + .budgetRow {
-  margin-top: 6px;
-}
-
-.budgetIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 20%;
-  color: white;
-}
-
-.budgetIcon svg {
-  stroke: white;
-  stroke-width: 2;
-  width: 60%;
-  height: 60%;
-}
-
-.link {
-  color: var(--primary-color);
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .nearbyScroll {
   display: flex;
   gap: 12px;

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -17,7 +17,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
-import { mapToRestingSpot, formatFacilities } from "@/lib/spot-mapper";
+import { mapToRestingSpot, formatFacilities, RawRestingSpot } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -94,7 +94,7 @@ export default function RestingDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  const spot = mapToRestingSpot(spotData);
+  const spot = mapToRestingSpot(spotData as unknown as RawRestingSpot);
 
   const photoUrls = assetData
     ? (assetData as unknown as { is_photo_gallery: boolean, gallery_order: number, url: string }[])

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -11,13 +11,13 @@ import {
   ChevronLeft,
   X,
 } from "lucide-react";
-import { RestingSpot } from '@/types/spot'
 
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { mapToRestingSpot } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -94,58 +94,7 @@ export default function RestingDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  // Cast dynamic data to internal interfaces for property access
-  const spotRaw = spotData as unknown as {
-    id: number;
-    name: string;
-    catchphrase?: string;
-    distance_from_transit?: string;
-    stay_duration?: string;
-    fukureko_comment?: string;
-    address: string;
-    business_hours?: string;
-    phone_number?: string;
-    nearest_station?: string;
-    website_url?: string;
-    average_budget?: string | number;
-    place_type: string;
-    pricing?: Record<string, unknown>;
-    facilities?: Record<string, unknown>;
-    updated_at: string;
-    created_at: string;
-    nearby_coin_lockers?: string;
-    parking_info?: string;
-    payment_methods?: string[];
-    closed_days?: string;
-    seating_info?: string;
-    remarks?: string;
-  };
-
-  const spot: RestingSpot = {
-    id: spotRaw.id,
-    name: spotRaw.name,
-    catchphrase: spotRaw.catchphrase,
-    distanceFromTransit: spotRaw.distance_from_transit,
-    stayDuration: spotRaw.stay_duration,
-    fukurekoComment: spotRaw.fukureko_comment,
-    address: spotRaw.address,
-    businessHours: spotRaw.business_hours,
-    phoneNumber: spotRaw.phone_number,
-    nearestStation: spotRaw.nearest_station,
-    websiteUrl: spotRaw.website_url,
-    averageBudget: spotRaw.average_budget,
-    placeType: spotRaw.place_type,
-    pricing: spotRaw.pricing || {},
-    facilities: spotRaw.facilities || {},
-    updatedAt: new Date(spotRaw.updated_at),
-    createdAt: new Date(spotRaw.created_at),
-    nearbyCoinLockers: spotRaw.nearby_coin_lockers,
-    parkingInfo: spotRaw.parking_info,
-    paymentMethods: spotRaw.payment_methods,
-    closedDays: spotRaw.closed_days,
-    seatingInfo: spotRaw.seating_info,
-    remarks: spotRaw.remarks,
-  };
+  const spot = mapToRestingSpot(spotData);
 
   const photoUrls = assetData
     ? (assetData as unknown as { is_photo_gallery: boolean, gallery_order: number, url: string }[])
@@ -222,7 +171,9 @@ export default function RestingDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || '情報なし' },
+            { label: "営業時間", value: spot.businessHours || "情報なし" },
+            { label: "座席情報", value: spot.seatingInfo || "情報なし" },
+            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
             { 
               label: "ウェブサイト", 
               value: spot.websiteUrl ? (

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -17,6 +17,7 @@ import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
+import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -218,37 +219,19 @@ export default function RestingDetailPage({ params }: Props) {
           <div className={styles.sectionBar}></div>
           <h2 className={styles.sectionTitle}>基本情報</h2>
         </div>
-        <div className={styles.infoTable}>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>住所</div>
-            <div className={styles.infoValue}>{spot.address}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>営業時間</div>
-            <div className={styles.infoValue}>{spot.businessHours || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>ウェブサイト</div>
-            <div className={styles.infoValue}>
-              {spot.websiteUrl ? (
-                <a 
-                  href={spot.websiteUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className={styles.link}
-                >
-                  {spot.websiteUrl}
-                </a>
-              ) : (
-                "情報なし"
-              )}
-            </div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>備考</div>
-            <div className={styles.infoValue}>{spot.remarks || "無し"}</div>
-          </div>
-        </div>
+        <SpotInfoTable 
+          items={[
+            { label: "住所", value: spot.address },
+            { label: "営業時間", value: spot.businessHours || '情報なし' },
+            { 
+              label: "ウェブサイト", 
+              value: spot.websiteUrl ? (
+                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
+              ) : "情報なし"
+            },
+            { label: "備考", value: spot.remarks || "無し" },
+          ]}
+        />
       </div>
 
       {/* Nearby Spots Section */}

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -17,7 +17,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
-import { mapToRestingSpot } from "@/lib/spot-mapper";
+import { mapToRestingSpot, formatFacilities } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -144,12 +144,14 @@ export default function RestingDetailPage({ params }: Props) {
         </div>
         <div className={styles.safetyGrid}>
           <div className={styles.safetyCard}>
-            <p className={styles.safetyLabel}>滞在目安</p>
-            <p className={styles.safetyValue}>{spot.stayDuration || '情報なし'}</p>
+            <p className={styles.safetyLabel}>座席情報</p>
+            <p className={styles.safetyValue}>{spot.seatingInfo || "情報なし"}</p>
           </div>
           <div className={styles.safetyCard}>
-            <p className={styles.safetyLabel}>座席情報</p>
-            <p className={styles.safetyValue}>{spot.seatingInfo || '情報なし'}</p>
+            <p className={styles.safetyLabel}>設備</p>
+            <p className={styles.safetyValue}>
+              {formatFacilities(spot.facilities).join("、") || "情報なし"}
+            </p>
           </div>
         </div>
       </div>
@@ -171,16 +173,18 @@ export default function RestingDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || "情報なし" },
-            { label: "座席情報", value: spot.seatingInfo || "情報なし" },
-            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
+            { label: "営業時間", value: spot.businessHours },
+            { label: "電話番号", value: spot.phoneNumber },
+            { label: "定休日", value: spot.closedDays },
+            { label: "滞在目安", value: spot.stayDuration },
+            { label: "座席情報", value: spot.seatingInfo },
+            { label: "支払方法", value: spot.paymentMethods },
+            { label: "駐車場", value: spot.parkingInfo },
             { 
               label: "ウェブサイト", 
-              value: spot.websiteUrl ? (
-                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
-              ) : "情報なし"
+              value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "備考", value: spot.remarks || "無し" },
+            { label: "備考", value: spot.remarks },
           ]}
         />
       </div>

--- a/miniApp/frontend/app/spots/resting/page.module.css
+++ b/miniApp/frontend/app/spots/resting/page.module.css
@@ -157,42 +157,6 @@
   color: #666;
 }
 
-.infoTable {
-  width: 100%;
-  background-color: #f5f5f5;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.infoRow {
-  display: flex;
-  padding: 0.8rem;
-  border-bottom: 1px solid white;
-}
-
-.infoRow:last-child {
-  border-bottom: none;
-}
-
-.infoLabel {
-  width: 90px;
-  font-weight: bold;
-  font-size: 0.9rem;
-  color: var(--text-black);
-}
-
-.infoValue {
-  flex: 1;
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-
-.link {
-  color: var(--primary-color);
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .actionFooter {
   position: fixed;
   bottom: 0;

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -19,7 +19,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
-import { mapToShop } from "@/lib/spot-mapper";
+import { mapToShop, RawShop } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -99,7 +99,7 @@ export default function ShopDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  const spot = mapToShop(spotData);
+  const spot = mapToShop(spotData as unknown as RawShop);
 
   const assetMap = (assetData as unknown as { id: number, url: string }[]).reduce((acc, asset) => {
     acc[asset.id] = asset.url;

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -202,28 +202,17 @@ export default function ShopDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || "情報なし" },
-            { label: "電話番号", value: spot.phoneNumber || "情報なし" },
-            { label: "定休日", value: spot.closedDays || "情報なし" },
-            { 
-              label: "支払方法", 
-              value: Array.isArray(spot.paymentMethods) ? (
-                spot.paymentMethods.map((method, idx) => (
-                  <div key={idx}>{method}</div>
-                ))
-              ) : (
-                spot.paymentMethods || "情報なし"
-              )
-            },
-            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
+            { label: "営業時間", value: spot.businessHours },
+            { label: "電話番号", value: spot.phoneNumber },
+            { label: "定休日", value: spot.closedDays },
+            { label: "支払方法", value: spot.paymentMethods },
+            { label: "駐車場", value: spot.parkingInfo },
             { 
               label: "ウェブサイト", 
-              value: spot.websiteUrl ? (
-                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
-              ) : "情報なし"
+              value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "店舗コメント", value: spot.shopComment || "無し" },
-            { label: "備考", value: spot.remarks || "無し" },
+            { label: "スポットコメント", value: spot.shopComment },
+            { label: "備考", value: spot.remarks },
           ]}
         />
       </div>

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -11,7 +11,6 @@ import {
   ChevronLeft,
   X,
 } from "lucide-react";
-import { Shop } from '@/types/spot'
 import { Menu } from '@/types/menu'
 
 import RecommendMenu from "@/components/atoms/recommendMenu/RecommendMenu";
@@ -20,6 +19,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { mapToShop } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -99,58 +99,7 @@ export default function ShopDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  // Cast dynamic data to internal interfaces for property access
-  const spotRaw = spotData as unknown as {
-    id: number;
-    name: string;
-    catchphrase?: string;
-    distance_from_transit?: string;
-    stay_duration?: string;
-    fukureko_comment?: string;
-    address: string;
-    business_hours?: string;
-    phone_number?: string;
-    nearest_station?: string;
-    website_url?: string;
-    average_budget?: string | number;
-    place_type: string;
-    pricing?: Record<string, unknown>;
-    facilities?: Record<string, unknown>;
-    updated_at: string;
-    created_at: string;
-    nearby_coin_lockers?: string;
-    parking_info?: string;
-    payment_methods?: string[];
-    closed_days?: string;
-    shop_comment?: string;
-    remarks?: string;
-  };
-
-  const spot: Shop = {
-    id: spotRaw.id,
-    name: spotRaw.name,
-    catchphrase: spotRaw.catchphrase,
-    distanceFromTransit: spotRaw.distance_from_transit,
-    stayDuration: spotRaw.stay_duration,
-    fukurekoComment: spotRaw.fukureko_comment,
-    address: spotRaw.address,
-    businessHours: spotRaw.business_hours,
-    phoneNumber: spotRaw.phone_number,
-    nearestStation: spotRaw.nearest_station,
-    websiteUrl: spotRaw.website_url,
-    averageBudget: spotRaw.average_budget,
-    placeType: spotRaw.place_type,
-    pricing: spotRaw.pricing || {},
-    facilities: spotRaw.facilities || {},
-    updatedAt: new Date(spotRaw.updated_at),
-    createdAt: new Date(spotRaw.created_at),
-    nearbyCoinLockers: spotRaw.nearby_coin_lockers,
-    parkingInfo: spotRaw.parking_info,
-    paymentMethods: spotRaw.payment_methods,
-    closedDays: spotRaw.closed_days,
-    shopComment: spotRaw.shop_comment,
-    remarks: spotRaw.remarks,
-  };
+  const spot = mapToShop(spotData);
 
   const assetMap = (assetData as unknown as { id: number, url: string }[]).reduce((acc, asset) => {
     acc[asset.id] = asset.url;
@@ -253,10 +202,11 @@ export default function ShopDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || '情報なし' },
-            { label: "電話番号", value: spot.phoneNumber || '情報なし' },
+            { label: "営業時間", value: spot.businessHours || "情報なし" },
+            { label: "電話番号", value: spot.phoneNumber || "情報なし" },
             { label: "定休日", value: spot.closedDays || "情報なし" },
             { label: "支払方法", value: spot.paymentMethods || "情報なし" },
+            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
             { 
               label: "ウェブサイト", 
               value: spot.websiteUrl ? (

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -205,7 +205,16 @@ export default function ShopDetailPage({ params }: Props) {
             { label: "営業時間", value: spot.businessHours || "情報なし" },
             { label: "電話番号", value: spot.phoneNumber || "情報なし" },
             { label: "定休日", value: spot.closedDays || "情報なし" },
-            { label: "支払方法", value: spot.paymentMethods || "情報なし" },
+            { 
+              label: "支払方法", 
+              value: Array.isArray(spot.paymentMethods) ? (
+                spot.paymentMethods.map((method, idx) => (
+                  <div key={idx}>{method}</div>
+                ))
+              ) : (
+                spot.paymentMethods || "情報なし"
+              )
+            },
             { label: "駐車場", value: spot.parkingInfo || "情報なし" },
             { 
               label: "ウェブサイト", 
@@ -213,6 +222,8 @@ export default function ShopDetailPage({ params }: Props) {
                 <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
               ) : "情報なし"
             },
+            { label: "店舗コメント", value: spot.shopComment || "無し" },
+            { label: "備考", value: spot.remarks || "無し" },
           ]}
         />
       </div>

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -19,6 +19,7 @@ import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
+import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -249,45 +250,21 @@ export default function ShopDetailPage({ params }: Props) {
           <div className={styles.sectionBar}></div>
           <h2 className={styles.sectionTitle}>基本情報</h2>
         </div>
-        <div className={styles.infoTable}>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>住所</div>
-            <div className={styles.infoValue}>{spot.address}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>営業時間</div>
-            <div className={styles.infoValue}>{spot.businessHours || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>電話番号</div>
-            <div className={styles.infoValue}>{spot.phoneNumber || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>定休日</div>
-            <div className={styles.infoValue}>{spot.closedDays || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>支払方法</div>
-            <div className={styles.infoValue}>{spot.paymentMethods || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>ウェブサイト</div>
-            <div className={styles.infoValue}>
-              {spot.websiteUrl ? (
-                <a 
-                  href={spot.websiteUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className={styles.link}
-                >
-                  {spot.websiteUrl}
-                </a>
-              ) : (
-                "情報なし"
-              )}
-            </div>
-          </div>
-        </div>
+        <SpotInfoTable 
+          items={[
+            { label: "住所", value: spot.address },
+            { label: "営業時間", value: spot.businessHours || '情報なし' },
+            { label: "電話番号", value: spot.phoneNumber || '情報なし' },
+            { label: "定休日", value: spot.closedDays || "情報なし" },
+            { label: "支払方法", value: spot.paymentMethods || "情報なし" },
+            { 
+              label: "ウェブサイト", 
+              value: spot.websiteUrl ? (
+                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
+              ) : "情報なし"
+            },
+          ]}
+        />
       </div>
 
       {/* Nearby Spots Section */}

--- a/miniApp/frontend/app/spots/shop/page.module.css
+++ b/miniApp/frontend/app/spots/shop/page.module.css
@@ -157,36 +157,6 @@
   color: #666;
 }
 
-.infoTable {
-  width: 100%;
-  background-color: #f5f5f5;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.infoRow {
-  display: flex;
-  padding: 0.8rem;
-  border-bottom: 1px solid white;
-}
-
-.infoRow:last-child {
-  border-bottom: none;
-}
-
-.infoLabel {
-  width: 90px;
-  font-weight: bold;
-  font-size: 0.9rem;
-  color: var(--text-black);
-}
-
-.infoValue {
-  flex: 1;
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-
 .link {
   color: var(--primary-color);
   text-decoration: underline;

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -174,17 +174,16 @@ export default function SightseeingDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || "情報なし" },
-            { label: "電話番号", value: spot.phoneNumber || "情報なし" },
-            { label: "定休日", value: spot.closedDays || "情報なし" },
-            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
+            { label: "営業時間", value: spot.businessHours },
+            { label: "電話番号", value: spot.phoneNumber },
+            { label: "定休日", value: spot.closedDays },
+            { label: "支払方法", value: spot.paymentMethods },
+            { label: "駐車場", value: spot.parkingInfo },
             { 
               label: "ウェブサイト", 
-              value: spot.websiteUrl ? (
-                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
-              ) : "情報なし"
+              value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "備考", value: spot.remarks || "無し" },
+            { label: "備考", value: spot.remarks },
           ]}
         />
       </div>

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -11,13 +11,13 @@ import {
   ChevronLeft,
   X,
 } from "lucide-react";
-import { SightseeingSpot } from '@/types/spot'
 
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { mapToSightseeingSpot } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -97,60 +97,7 @@ export default function SightseeingDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  // Cast dynamic data to internal interfaces for property access
-  const spotRaw = spotData as unknown as {
-    id: number;
-    name: string;
-    catchphrase?: string;
-    distance_from_transit?: string;
-    stay_duration?: string;
-    fukureko_comment?: string;
-    address: string;
-    business_hours?: string;
-    phone_number?: string;
-    nearest_station?: string;
-    website_url?: string;
-    average_budget?: string | number;
-    place_type: string;
-    pricing?: Record<string, unknown>;
-    facilities?: Record<string, unknown>;
-    updated_at: string;
-    created_at: string;
-    nearby_coin_lockers?: string;
-    parking_info?: string;
-    payment_methods?: string[];
-    closed_days?: string;
-    avg_wait_time?: string;
-    remarks?: string;
-    latitude: string;
-    longitude: string;
-  };
-
-  const spot: SightseeingSpot = {
-    id: spotRaw.id,
-    name: spotRaw.name,
-    catchphrase: spotRaw.catchphrase,
-    distanceFromTransit: spotRaw.distance_from_transit,
-    stayDuration: spotRaw.stay_duration,
-    fukurekoComment: spotRaw.fukureko_comment,
-    address: spotRaw.address,
-    businessHours: spotRaw.business_hours,
-    phoneNumber: spotRaw.phone_number,
-    nearestStation: spotRaw.nearest_station,
-    websiteUrl: spotRaw.website_url,
-    averageBudget: spotRaw.average_budget,
-    placeType: spotRaw.place_type,
-    pricing: spotRaw.pricing || {},
-    facilities: spotRaw.facilities || {},
-    updatedAt: new Date(spotRaw.updated_at),
-    createdAt: new Date(spotRaw.created_at),
-    nearbyCoinLockers: spotRaw.nearby_coin_lockers,
-    parkingInfo: spotRaw.parking_info,
-    paymentMethods: spotRaw.payment_methods,
-    closedDays: spotRaw.closed_days,
-    avgWaitTime: spotRaw.avg_wait_time,
-    remarks: spotRaw.remarks,
-  };
+  const spot = mapToSightseeingSpot(spotData);
 
   const photoUrls = assetData
     ? (assetData as unknown as { is_photo_gallery: boolean, gallery_order: number, url: string }[])
@@ -227,9 +174,10 @@ export default function SightseeingDetailPage({ params }: Props) {
         <SpotInfoTable 
           items={[
             { label: "住所", value: spot.address },
-            { label: "営業時間", value: spot.businessHours || '情報なし' },
-            { label: "電話番号", value: spot.phoneNumber || '情報なし' },
+            { label: "営業時間", value: spot.businessHours || "情報なし" },
+            { label: "電話番号", value: spot.phoneNumber || "情報なし" },
             { label: "定休日", value: spot.closedDays || "情報なし" },
+            { label: "駐車場", value: spot.parkingInfo || "情報なし" },
             { 
               label: "ウェブサイト", 
               value: spot.websiteUrl ? (

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -17,7 +17,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
-import { mapToSightseeingSpot } from "@/lib/spot-mapper";
+import { mapToSightseeingSpot, RawSightseeingSpot } from "@/lib/spot-mapper";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -97,7 +97,7 @@ export default function SightseeingDetailPage({ params }: Props) {
 
   if (loading || !spotData) return null;
 
-  const spot = mapToSightseeingSpot(spotData);
+  const spot = mapToSightseeingSpot(spotData as unknown as RawSightseeingSpot);
 
   const photoUrls = assetData
     ? (assetData as unknown as { is_photo_gallery: boolean, gallery_order: number, url: string }[])

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -17,6 +17,7 @@ import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
+import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -223,45 +224,21 @@ export default function SightseeingDetailPage({ params }: Props) {
           <div className={styles.sectionBar}></div>
           <h2 className={styles.sectionTitle}>基本情報</h2>
         </div>
-        <div className={styles.infoTable}>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>住所</div>
-            <div className={styles.infoValue}>{spot.address}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>営業時間</div>
-            <div className={styles.infoValue}>{spot.businessHours || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>電話番号</div>
-            <div className={styles.infoValue}>{spot.phoneNumber || '情報なし'}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>定休日</div>
-            <div className={styles.infoValue}>{spot.closedDays || "情報なし"}</div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>ウェブサイト</div>
-            <div className={styles.infoValue}>
-              {spot.websiteUrl ? (
-                <a 
-                  href={spot.websiteUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className={styles.link}
-                >
-                  {spot.websiteUrl}
-                </a>
-              ) : (
-                "情報なし"
-              )}
-            </div>
-          </div>
-          <div className={styles.infoRow}>
-            <div className={styles.infoLabel}>備考</div>
-            <div className={styles.infoValue}>{spot.remarks || "無し"}</div>
-          </div>
-        </div>
+        <SpotInfoTable 
+          items={[
+            { label: "住所", value: spot.address },
+            { label: "営業時間", value: spot.businessHours || '情報なし' },
+            { label: "電話番号", value: spot.phoneNumber || '情報なし' },
+            { label: "定休日", value: spot.closedDays || "情報なし" },
+            { 
+              label: "ウェブサイト", 
+              value: spot.websiteUrl ? (
+                <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
+              ) : "情報なし"
+            },
+            { label: "備考", value: spot.remarks || "無し" },
+          ]}
+        />
       </div>
 
       {/* Nearby Spots Section */}

--- a/miniApp/frontend/app/spots/sightseeing/page.module.css
+++ b/miniApp/frontend/app/spots/sightseeing/page.module.css
@@ -157,42 +157,6 @@
   color: #666;
 }
 
-.infoTable {
-  width: 100%;
-  background-color: #f5f5f5;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.infoRow {
-  display: flex;
-  padding: 0.8rem;
-  border-bottom: 1px solid white;
-}
-
-.infoRow:last-child {
-  border-bottom: none;
-}
-
-.infoLabel {
-  width: 90px;
-  font-weight: bold;
-  font-size: 0.9rem;
-  color: var(--text-black);
-}
-
-.infoValue {
-  flex: 1;
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-
-.link {
-  color: var(--primary-color);
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .actionFooter {
   position: fixed;
   bottom: 0;

--- a/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.module.css
+++ b/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.module.css
@@ -1,0 +1,68 @@
+.infoTable {
+  width: 100%;
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.infoRow {
+  display: flex;
+  padding: 0.8rem;
+  border-bottom: 1px solid white;
+}
+
+.infoRow:last-child {
+  border-bottom: none;
+}
+
+.infoLabel {
+  width: 90px;
+  flex-shrink: 0;
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: var(--text-black);
+}
+
+.infoValue {
+  flex: 1;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  /* 長いURLや英単語への対策 */
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+/* リンク用の共通スタイル */
+.link {
+  color: var(--primary-color);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* レストラン等で使用する予算行のスタイル */
+.budgetRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.budgetRow + .budgetRow {
+  margin-top: 6px;
+}
+
+.budgetIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 20%;
+  color: white;
+}
+
+.budgetIcon svg {
+  stroke: white;
+  stroke-width: 2;
+  width: 60%;
+  height: 60%;
+}

--- a/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
+++ b/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
@@ -13,40 +13,64 @@ interface Props {
 export const SpotInfoTable: FunctionComponent<Props> = ({ items }) => {
   return (
     <div className={styles.infoTable}>
-      {items.map((item, index) => (
-        <div key={index} className={styles.infoRow}>
-          <div className={styles.infoLabel}>{item.label}</div>
-          <div className={styles.infoValue}>{item.value}</div>
-        </div>
-      ))}
+      {items.map((item, index) => {
+        let displayValue = item.value;
+
+        // 配列のハンドリング
+        if (Array.isArray(displayValue)) {
+          if (displayValue.length > 0) {
+            displayValue = displayValue.map((v, i) => <div key={i}>{v}</div>);
+          } else {
+            displayValue = null;
+          }
+        }
+
+        // 判定用のフラグ
+        const isEmpty = 
+          displayValue === null || 
+          displayValue === undefined || 
+          displayValue === "" || 
+          (Array.isArray(item.value) && item.value.length === 0);
+
+        return (
+          <div key={index} className={styles.infoRow}>
+            <div className={styles.infoLabel}>{item.label}</div>
+            <div className={styles.infoValue}>{isEmpty ? "情報なし" : displayValue}</div>
+          </div>
+        );
+      })}
     </div>
   );
 };
 
-// 補助的な共通パーツ（予算表示用など）もエクスポートしておくと便利
-export const InfoLink: FunctionComponent<{ href: string; children: ReactNode }> = ({
+// 補助的な共通パーツ（リンク用）
+export const InfoLink: FunctionComponent<{ href: string | null | undefined; children: ReactNode }> = ({
   href,
   children,
-}) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    className={styles.link}
-  >
-    {children}
-  </a>
-);
+}) => {
+  if (!href) return <>情報なし</>;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.link}
+    >
+      {children}
+    </a>
+  );
+};
 
+// 補助的な共通パーツ（予算表示用）
 export const BudgetRow: FunctionComponent<{
   icon: ReactNode;
   iconBgColor: string;
-  label: string | number;
+  label: string | number | undefined | null;
 }> = ({ icon, iconBgColor, label }) => (
   <div className={styles.budgetRow}>
     <span className={styles.budgetIcon} style={{ backgroundColor: iconBgColor }}>
       {icon}
     </span>
-    <span>{label}</span>
+    <span>{label ? label : "情報なし"}</span>
   </div>
 );

--- a/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
+++ b/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
@@ -1,0 +1,52 @@
+import React, { FunctionComponent, ReactNode } from "react";
+import styles from "./SpotInfoTable.module.css";
+
+export interface InfoItem {
+  label: string;
+  value: ReactNode;
+}
+
+interface Props {
+  items: InfoItem[];
+}
+
+export const SpotInfoTable: FunctionComponent<Props> = ({ items }) => {
+  return (
+    <div className={styles.infoTable}>
+      {items.map((item, index) => (
+        <div key={index} className={styles.infoRow}>
+          <div className={styles.infoLabel}>{item.label}</div>
+          <div className={styles.infoValue}>{item.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// 補助的な共通パーツ（予算表示用など）もエクスポートしておくと便利
+export const InfoLink: FunctionComponent<{ href: string; children: ReactNode }> = ({
+  href,
+  children,
+}) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={styles.link}
+  >
+    {children}
+  </a>
+);
+
+export const BudgetRow: FunctionComponent<{
+  icon: ReactNode;
+  iconBgColor: string;
+  label: string | number;
+}> = ({ icon, iconBgColor, label }) => (
+  <div className={styles.budgetRow}>
+    <span className={styles.budgetIcon} style={{ backgroundColor: iconBgColor }}>
+      {icon}
+    </span>
+    <span>{label}</span>
+  </div>
+);

--- a/miniApp/frontend/lib/spot-mapper.ts
+++ b/miniApp/frontend/lib/spot-mapper.ts
@@ -52,6 +52,30 @@ export interface RawSightseeingSpot extends RawSpot {
 }
 
 /**
+ * 設備の表示名マッピング
+ */
+export const FACILITY_LABELS: Record<string, string> = {
+  has_wifi: "Wi-Fiあり",
+  has_outlet: "コンセントあり",
+  is_barrier_free: "バリアフリー",
+  is_smoking_allowed: "喫煙可",
+  has_parking: "駐車場あり",
+  has_restroom: "トイレあり",
+  has_nursing_room: "授乳室あり",
+  // 必要に応じて追加
+};
+
+/**
+ * 設備オブジェクトを表示用の文字列配列に変換する
+ */
+export function formatFacilities(facilities: Record<string, unknown> | undefined): string[] {
+  if (!facilities) return [];
+  return Object.entries(facilities)
+    .filter(([key, value]) => value === true && FACILITY_LABELS[key])
+    .map(([key]) => FACILITY_LABELS[key]);
+}
+
+/**
  * DBの共通カラムをフロントエンドのSpot型にマッピングする
  */
 function mapBaseSpot(raw: RawSpot): Spot {

--- a/miniApp/frontend/lib/spot-mapper.ts
+++ b/miniApp/frontend/lib/spot-mapper.ts
@@ -1,0 +1,110 @@
+import { Spot, Restaurant, Shop, RestingSpot, SightseeingSpot } from "@/types/spot";
+
+/**
+ * API/DBからの生のデータ構造を定義（スネークケース）
+ */
+export interface RawSpot {
+  id: number;
+  name: string;
+  catchphrase?: string;
+  distance_from_transit?: string;
+  stay_duration?: string;
+  fukureko_comment?: string;
+  address: string;
+  business_hours?: string;
+  phone_number?: string;
+  nearest_station?: string;
+  website_url?: string;
+  average_budget?: string | number;
+  place_type: string;
+  pricing?: Record<string, unknown>;
+  facilities?: Record<string, unknown>;
+  updated_at: string;
+  created_at: string;
+  nearby_coin_lockers?: string;
+  parking_info?: string;
+  payment_methods?: string[];
+  closed_days?: string;
+  remarks?: string;
+  latitude?: string | number;
+  longitude?: string | number;
+}
+
+export interface RawRestaurant extends RawSpot {
+  avg_lunch_budget?: string;
+  avg_dinner_budget?: string;
+  seating_info?: number;
+  avg_wait_time?: string;
+  reservation_url?: string;
+}
+
+export interface RawRestingSpot extends RawSpot {
+  seating_info?: string;
+}
+
+export interface RawSightseeingSpot extends RawSpot {
+  avg_wait_time?: string;
+}
+
+/**
+ * DBの共通カラムをフロントエンドのSpot型にマッピングする
+ */
+function mapBaseSpot(raw: RawSpot): Spot {
+  return {
+    id: raw.id,
+    name: raw.name,
+    catchphrase: raw.catchphrase,
+    distanceFromTransit: raw.distance_from_transit,
+    stayDuration: raw.stay_duration,
+    fukurekoComment: raw.fukureko_comment,
+    address: raw.address,
+    businessHours: raw.business_hours,
+    phoneNumber: raw.phone_number,
+    nearestStation: raw.nearest_station,
+    websiteUrl: raw.website_url,
+    averageBudget: raw.average_budget,
+    placeType: raw.place_type,
+    pricing: raw.pricing || {},
+    facilities: raw.facilities || {},
+    updatedAt: new Date(raw.updated_at),
+    createdAt: new Date(raw.created_at),
+    nearbyCoinLockers: raw.nearby_coin_lockers,
+    parkingInfo: raw.parking_info,
+    paymentMethods: raw.payment_methods,
+    closedDays: raw.closed_days,
+    remarks: raw.remarks,
+    latitude: raw.latitude ? (typeof raw.latitude === "string" ? parseFloat(raw.latitude) : raw.latitude) : undefined,
+    longitude: raw.longitude ? (typeof raw.longitude === "string" ? parseFloat(raw.longitude) : raw.longitude) : undefined,
+  };
+}
+
+export function mapToRestaurant(raw: RawRestaurant): Restaurant {
+  return {
+    ...mapBaseSpot(raw),
+    avgLunchBudget: raw.avg_lunch_budget,
+    avgDinnerBudget: raw.avg_dinner_budget,
+    seatingInfo: raw.seating_info,
+    avgWaitTime: raw.avg_wait_time,
+    reservationURL: raw.reservation_url,
+  };
+}
+
+export function mapToShop(raw: RawSpot): Shop {
+  return {
+    ...mapBaseSpot(raw),
+  };
+}
+
+export function mapToRestingSpot(raw: RawRestingSpot): RestingSpot {
+  return {
+    ...mapBaseSpot(raw),
+    seatingInfo: raw.seating_info,
+  };
+}
+
+export function mapToSightseeingSpot(raw: RawSightseeingSpot): SightseeingSpot {
+  return {
+    ...mapBaseSpot(raw),
+    avgWaitTime: raw.avg_wait_time,
+  };
+}

--- a/miniApp/frontend/lib/spot-mapper.ts
+++ b/miniApp/frontend/lib/spot-mapper.ts
@@ -36,6 +36,11 @@ export interface RawRestaurant extends RawSpot {
   seating_info?: number;
   avg_wait_time?: string;
   reservation_url?: string;
+  restaurant_comment?: string;
+}
+
+export interface RawShop extends RawSpot {
+  shop_comment?: string;
 }
 
 export interface RawRestingSpot extends RawSpot {
@@ -86,12 +91,14 @@ export function mapToRestaurant(raw: RawRestaurant): Restaurant {
     seatingInfo: raw.seating_info,
     avgWaitTime: raw.avg_wait_time,
     reservationURL: raw.reservation_url,
+    restaurantComment: raw.restaurant_comment,
   };
 }
 
-export function mapToShop(raw: RawSpot): Shop {
+export function mapToShop(raw: RawShop): Shop {
   return {
     ...mapBaseSpot(raw),
+    shopComment: raw.shop_comment,
   };
 }
 


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
Spotsの基本情報に関するバグを修正しました

## 変更内容
- SpotInfoTable コンポーネントを新規作成し、共通のスタイルを定義
- 飲食店、休憩所、ショップ、観光地の各詳細ページで共通コンポーネントを使用するように修正
- 重複していたテーブル表示用のロジックとCSSを削除
- API/DBからの生データからフロントエンド用型への変換処理を `lib/spot-mapper.ts` に集約
- 各詳細ページ（レストラン、休憩スポット、ショップ、観光スポット）での冗長なマッピング処理を共通関数に置き換え
- 休憩スポットや観光スポットなどの詳細ページにおいて、駐車場情報や座席情報の表示項目を追加
- 飲食店詳細に「施設コメント」、店舗詳細に「店舗コメント」と「備考」の表示項目を追加
- 支払方法が配列データの場合に、各要素を改行して表示するよう改善
- APIからの生データ（RawRestaurant, RawShop）にコメント用フィールドを定義し、マッピング処理を追加
- SpotInfoTable、InfoLink、BudgetRowコンポーネントで未設定データのハンドリングを共通化
- spot-mapper.tsに設備情報のマッピング定義とフォーマット関数を追加
- 休憩スポット詳細ページに設備情報を表示するように変更
- 各詳細ページの情報テーブル項目を整理し、重複した「情報なし」の条件分岐を削除
- レストラン詳細ページ内での内部変数名をspotに統一し一貫性を向上



## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 