### PR TITLE
feat: スポット詳細ページに免責事項を追加しタグ表示のUIを調整

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -23,6 +23,7 @@ import { useFavorites } from '@/hooks/useFavorites';
 import { SpotDetailSkeleton } from '@/components/atoms/spotCard/SpotDetailSkeleton';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink, BudgetRow } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToRestaurant, RawRestaurant } from "@/lib/spot-mapper";
 
 interface Props {
@@ -268,6 +269,8 @@ export default function RestaurantDetailPage({ params }: Props) {
           currentId={spot.id} 
         />
       )}
+
+      <Disclaimer />
 
       {/* Action Footer */}
       <div className={styles.actionFooter}>

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -17,6 +17,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToRestingSpot, formatFacilities, RawRestingSpot } from "@/lib/spot-mapper";
 
 interface Props {
@@ -197,6 +198,8 @@ export default function RestingDetailPage({ params }: Props) {
           currentId={spot.id} 
         />
       )}
+
+      <Disclaimer />
 
       {/* Action Footer */}
       <div className={styles.actionFooter}>

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -19,6 +19,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToShop, RawShop } from "@/lib/spot-mapper";
 
 interface Props {
@@ -225,6 +226,8 @@ export default function ShopDetailPage({ params }: Props) {
           currentId={spot.id} 
         />
       )}
+
+      <Disclaimer />
 
       {/* Action Footer */}
       <div className={styles.actionFooter}>

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -17,6 +17,7 @@ import Tags from "@/components/atoms/tags/Tags";
 import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
+import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToSightseeingSpot, RawSightseeingSpot } from "@/lib/spot-mapper";
 
 interface Props {
@@ -196,6 +197,8 @@ export default function SightseeingDetailPage({ params }: Props) {
           currentId={spot.id} 
         />
       )}
+
+      <Disclaimer />
 
       {/* Action Footer */}
       <div className={styles.actionFooter}>

--- a/miniApp/frontend/components/atoms/disclaimer/Disclaimer.module.css
+++ b/miniApp/frontend/components/atoms/disclaimer/Disclaimer.module.css
@@ -1,0 +1,7 @@
+.disclaimer {
+  font-size: 0.7rem;
+  color: #888;
+  text-align: center;
+  padding: 1.5rem 1.2rem;
+  background-color: white;
+}

--- a/miniApp/frontend/components/atoms/disclaimer/Disclaimer.tsx
+++ b/miniApp/frontend/components/atoms/disclaimer/Disclaimer.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import styles from "./Disclaimer.module.css";
+
+export const Disclaimer = () => (
+  <div className={styles.disclaimer}>
+    ※ 最新の情報とは異なる可能性があります
+  </div>
+);

--- a/miniApp/frontend/components/atoms/tags/Tags.module.css
+++ b/miniApp/frontend/components/atoms/tags/Tags.module.css
@@ -27,14 +27,14 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 500;
   margin-top: 4px;
   margin-bottom: 1.5rem;
   cursor: pointer;
   background: none;
   border: none;
-  color: inherit;
+  color: #888;
   padding: 4px 0;
   width: fit-content;
   align-self: center;

--- a/miniApp/frontend/components/atoms/tags/Tags.tsx
+++ b/miniApp/frontend/components/atoms/tags/Tags.tsx
@@ -41,9 +41,9 @@ export default function Tags ({ tags = [] }: TagsProps) {
             aria-expanded={showAllTags}
           >
             {showAllTags ? (
-              <>タグを閉じる <ChevronUp size={16} /></>
+              <>閉じる <ChevronUp size={16} /></>
             ) : (
-              <>タグをすべてみる <ChevronDown size={16} /></>
+              <>すべて見る <ChevronDown size={16} /></>
             )}
           </button>
         )}


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポット詳細ページに免責事項を追加しタグ表示のUIを調整
## 変更の理由・背景
- タグをすべて見るはすべて見るで伝わると感じたため
-
## 変更内容
- 免責事項を表示するDisclaimerコンポーネントを新規作成し、各スポット詳細ページに追加
- タグの展開・折りたたみボタンのテキストを「すべて見る」「閉じる」に簡潔化
- タグ表示切り替えボタンのフォントサイズを縮小し、カラーをグレーに変更して視認性を調整


## スクリーンショット（UI変更がある場合）

## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 