### PR TITLE
Fix: 昼と夜の平均価格が表示されない問題を修正しました

### DIFF
--- a/miniApp/frontend/app/api/search/route.ts
+++ b/miniApp/frontend/app/api/search/route.ts
@@ -45,6 +45,13 @@ export async function GET(request: Request) {
             updated_at: string;
             spot_tags?: SpotTag[];
             assets?: SpotAsset[];
+            restaurants?: {
+                avg_lunch_budget?: string;
+                avg_dinner_budget?: string;
+            } | {
+                avg_lunch_budget?: string;
+                avg_dinner_budget?: string;
+            }[];
         };
 
         let rawData: RawSpot[] = [];
@@ -69,6 +76,10 @@ export async function GET(request: Request) {
                     assets (
                         url,
                         is_cardthumbnail
+                    ),
+                    restaurants (
+                        avg_lunch_budget,
+                        avg_dinner_budget
                     )
                 `)
                 .or(`name.ilike.%${keyword}%,catchphrase.ilike.%${keyword}%,fukureko_comment.ilike.%${keyword}%`);
@@ -98,6 +109,10 @@ export async function GET(request: Request) {
                             assets (
                                 url,
                                 is_cardthumbnail
+                            ),
+                            restaurants (
+                                avg_lunch_budget,
+                                avg_dinner_budget
                             )
                         )
                     )
@@ -117,6 +132,11 @@ export async function GET(request: Request) {
             const thumbnail = item.assets?.find((a: SpotAsset) => a.is_cardthumbnail === true);
             const imageSrc = thumbnail?.url || "/sampleImage.png";
 
+            // restaurantsテーブルのデータを取得
+            const restaurantDetail = Array.isArray(item.restaurants) 
+                ? item.restaurants[0] 
+                : item.restaurants;
+
             // place_type に基づいて pin画像 と 詳細URL を決定
             const type = item.place_type.toLowerCase();
             let pinKind = "/FoodPin.svg";
@@ -135,13 +155,14 @@ export async function GET(request: Request) {
 
             return {
                 id: item.id,
-                spotKind: item.place_type,
+                spotKind: item.place_type.toLowerCase(),
                 pinKind: pinKind,
                 spotName: item.name,
                 imageSrc: imageSrc,
                 spotTags: item.spot_tags?.map((st: SpotTag) => st.tags?.detail).filter(Boolean) || [],
                 detailURL: detailURL,
-                price1: typeof item.pricing === 'string' ? item.pricing : "価格情報なし",
+                price1: restaurantDetail?.avg_lunch_budget || (typeof item.pricing === 'string' ? item.pricing : "価格情報なし"),
+                price2: restaurantDetail?.avg_dinner_budget || "",
                 position: {
                     lat: typeof item.latitude === 'string' ? parseFloat(item.latitude) : item.latitude,
                     lng: typeof item.longitude === 'string' ? parseFloat(item.longitude) : item.longitude

--- a/miniApp/frontend/app/api/spotcard/route.ts
+++ b/miniApp/frontend/app/api/spotcard/route.ts
@@ -35,6 +35,10 @@ export async function GET(request: Request) {
                 assets (
                     url,
                     is_cardthumbnail
+                ),
+                restaurants (
+                    avg_lunch_budget,
+                    avg_dinner_budget
                 )
             `)
             .eq('id', id)
@@ -51,6 +55,11 @@ export async function GET(request: Request) {
         // サムネイル画像を取得（is_cardthumbnailがtrueのもの）
         const thumbnail = (data.assets as { url: string; is_cardthumbnail: boolean }[] | null)?.find((a) => a.is_cardthumbnail === true);
         const imageSrc = thumbnail?.url || "/sampleImage.png"; // 見つからなければデフォルト画像
+
+        // restaurantsテーブルのデータを取得
+        const restaurantDetail = Array.isArray(data.restaurants) 
+            ? data.restaurants[0] 
+            : data.restaurants;
 
         // Google Places API (New) から営業状況を取得 (resting_spot 以外)
         let isOpen: boolean | null = null;
@@ -84,7 +93,7 @@ export async function GET(request: Request) {
                 });
 
                 if (placesResponse.ok) {
-                    const placesData = await placesResponse.ok ? await placesResponse.json() : null;
+                    const placesData = await placesResponse.json();
                     if (placesData && placesData.places && placesData.places.length > 0) {
                         // currentOpeningHours.openNow があればそれを使用、なければデフォルトfalse
                         isOpen = placesData.places[0].currentOpeningHours?.openNow ?? false;
@@ -114,7 +123,7 @@ export async function GET(request: Request) {
         // MapSpotData (UI用) の形式に整形
         const formattedData = {
             id: data.id,
-            spotKind: data.place_type,
+            spotKind: data.place_type.toLowerCase(),
             pinKind: pinKind,
             spotName: data.name,
             isOpen: isOpen,
@@ -125,7 +134,8 @@ export async function GET(request: Request) {
                 return (tags as { detail: string } | null)?.detail;
             }).filter(Boolean) || [],
             detailURL: detailURL,
-            price1: typeof data.pricing === 'string' ? data.pricing : "価格情報なし", // pricingの形式に合わせて調整が必要
+            price1: restaurantDetail?.avg_lunch_budget || (typeof data.pricing === 'string' ? data.pricing : "価格情報なし"),
+            price2: restaurantDetail?.avg_dinner_budget || "",
             position: {
                 lat: parseFloat(data.latitude),
                 lng: parseFloat(data.longitude)

--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -64,11 +64,12 @@ export default function RestaurantDetailPage({ params }: Props) {
         return;
       }
 
-      // restaurantsテーブルのデータを取り出す（1対1または1対多の配列を想定）
+      // restaurantsテーブルのデータを取り出す（1対1の関係を想定）
       const restaurantDetail = Array.isArray(spotRes.data.restaurants) 
         ? spotRes.data.restaurants[0] 
         : spotRes.data.restaurants;
 
+      // restaurants側の追加情報をマージ（データがない場合は空オブジェクトをマージして不完全な状態を防ぐ）
       setSpotData({
         ...spotRes.data,
         ...restaurantDetail

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -36,6 +36,12 @@ const iconConfig: Record<string, { icon1: ReactNode; icon2: ReactNode | null; bg
     bg1: "#efab58",
     bg2: "#5C6BC0",
   },
+  cafe: {
+    icon1: <Sun />,
+    icon2: <Moon />,
+    bg1: "#efab58",
+    bg2: "#5C6BC0",
+  },
   sightseeing_spot: {
     icon1: <User />,
     icon2: <Baby />,

--- a/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
+++ b/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
@@ -66,11 +66,14 @@ export const BudgetRow: FunctionComponent<{
   icon: ReactNode;
   iconBgColor: string;
   label: string | number | undefined | null;
-}> = ({ icon, iconBgColor, label }) => (
-  <div className={styles.budgetRow}>
-    <span className={styles.budgetIcon} style={{ backgroundColor: iconBgColor }}>
-      {icon}
-    </span>
-    <span>{label ? label : "情報なし"}</span>
-  </div>
-);
+}> = ({ icon, iconBgColor, label }) => {
+  const displayLabel = (label ?? "") !== "" ? label : "情報なし";
+  return (
+    <div className={styles.budgetRow}>
+      <span className={styles.budgetIcon} style={{ backgroundColor: iconBgColor }}>
+        {icon}
+      </span>
+      <span>{displayLabel}</span>
+    </div>
+  );
+};

--- a/miniApp/frontend/lib/spot-mapper.ts
+++ b/miniApp/frontend/lib/spot-mapper.ts
@@ -15,7 +15,7 @@ export interface RawSpot {
   phone_number?: string;
   nearest_station?: string;
   website_url?: string;
-  average_budget?: string | number;
+  average_budget?: string;
   place_type: string;
   pricing?: Record<string, unknown>;
   facilities?: Record<string, unknown>;
@@ -33,7 +33,7 @@ export interface RawSpot {
 export interface RawRestaurant extends RawSpot {
   avg_lunch_budget?: string;
   avg_dinner_budget?: string;
-  seating_info?: number;
+  seating_info?: number | string;
   avg_wait_time?: string;
   reservation_url?: string;
   restaurant_comment?: string;
@@ -62,7 +62,6 @@ export const FACILITY_LABELS: Record<string, string> = {
   has_parking: "駐車場あり",
   has_restroom: "トイレあり",
   has_nursing_room: "授乳室あり",
-  // 必要に応じて追加
 };
 
 /**
@@ -108,11 +107,19 @@ function mapBaseSpot(raw: RawSpot): Spot {
 }
 
 export function mapToRestaurant(raw: RawRestaurant): Restaurant {
+  const base = mapBaseSpot(raw);
+
+  const parsedSeating = typeof raw.seating_info === 'string'
+    ? parseInt(raw.seating_info, 10)
+    : raw.seating_info;
+
   return {
-    ...mapBaseSpot(raw),
+    ...base,
     avgLunchBudget: raw.avg_lunch_budget,
     avgDinnerBudget: raw.avg_dinner_budget,
-    seatingInfo: raw.seating_info,
+    seatingInfo: (parsedSeating !== null && parsedSeating !== undefined && !isNaN(Number(parsedSeating)))
+      ? Number(parsedSeating)
+      : undefined,
     avgWaitTime: raw.avg_wait_time,
     reservationURL: raw.reservation_url,
     restaurantComment: raw.restaurant_comment,


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
昼と夜の平均価格が表示されない問題を修正しました
## 変更の理由・背景
- 

## 変更内容
- レストラン詳細情報のマージ処理を改善し、データ欠落による不整合を防止
- 予算表示コンポーネントにおいて、空文字列を適切に「情報なし」と表示するよう修正
- 座席数（seating_info）の型定義を調整し、文字列からのパース処理とバリデーションを追加
- Supabaseのクエリを更新し、restaurantsテーブルから昼夜の平均予算を取得するように変更
- APIレスポンスのprice1にランチ予算、price2にディナー予算を反映
- spotKindを小文字に変換して返却するように修正
- SpotCardコンポーネントのアイコン設定にcafeを追加
- spotcard APIでのGoogle Places APIレスポンス取得処理を整理

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 