### PR TITLE
fix: レストランおよびショップの詳細画面からスポットコメントの項目を削除

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -252,13 +252,11 @@ export default function RestaurantDetailPage({ params }: Props) {
             },
             { label: "支払方法", value: spot.paymentMethods },
             { label: "駐車場", value: spot.parkingInfo },
-            { 
-              label: "ウェブサイト", 
+            {
+              label: "ウェブサイト",
               value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "スポットコメント", value: spot.restaurantComment },
-            { label: "備考", value: spot.remarks },
-          ]}
+            { label: "備考", value: spot.remarks },          ]}
         />
       </div>
 

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -208,13 +208,11 @@ export default function ShopDetailPage({ params }: Props) {
             { label: "定休日", value: spot.closedDays },
             { label: "支払方法", value: spot.paymentMethods },
             { label: "駐車場", value: spot.parkingInfo },
-            { 
-              label: "ウェブサイト", 
+            {
+              label: "ウェブサイト",
               value: <InfoLink href={spot.websiteUrl}>{spot.websiteUrl}</InfoLink>
             },
-            { label: "スポットコメント", value: spot.shopComment },
-            { label: "備考", value: spot.remarks },
-          ]}
+            { label: "備考", value: spot.remarks },          ]}
         />
       </div>
 


### PR DESCRIPTION

<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
レストランおよびショップの詳細画面からスポットコメントの項目を削除

## 変更内容
- 飲食店とショップの詳細ページの情報テーブルから「スポットコメント」を削除
- ウェブサイト項目のフォーマットおよびインデントを整理


## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 