### PR TITLE
fix:カードのボタンや文字サイズの修正と、修正に合わせたカードスケルトンの調整

### DIFF
--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -84,7 +84,7 @@
 .cardImage {
     position: relative;
     width: 100%;
-    aspect-ratio: 16 / 5;
+    aspect-ratio: 16 / 8;
     overflow: hidden;
 }
 
@@ -183,13 +183,17 @@
 }
 
 .cardFooter > a {
-    height: clamp(30px, 7vw, 38px) !important;
-    font-size: clamp(0.65rem, 0.4rem + 1.2vw, 0.8rem) !important;
-    padding: 0 4px !important;
+    height: clamp(34px, 8vw, 44px) !important;
+    font-size: clamp(0.7rem, 0.4rem + 1.5vw, 0.85rem) !important;
+}
+
+.routeBtn,
+.heartBtn {
+    background-color: #f4f4f4 !important;
 }
 
 .cardFooter > button {
-    height: clamp(30px, 7vw, 38px) !important;
-    width: clamp(30px, 7vw, 38px) !important;
-    flex: 0 0 clamp(30px, 7vw, 38px) !important;
+    height: clamp(34px, 8vw, 44px) !important;
+    width: clamp(34px, 8vw, 44px) !important;
+    flex: 0 0 clamp(34px, 8vw, 44px) !important;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -178,17 +178,18 @@
 .cardFooter {
     padding: 0px 5% 10px 5%;
     display: flex;
-    gap: 8px;
+    gap: 12px;
     align-items: center;
 }
 
 .cardFooter > a {
-    height: clamp(34px, 8vw, 44px) !important;
-    font-size: clamp(0.7rem, 0.4rem + 1.5vw, 0.85rem) !important;
+    height: clamp(30px, 7vw, 38px) !important;
+    font-size: clamp(0.65rem, 0.4rem + 1.2vw, 0.8rem) !important;
+    padding: 0 4px !important;
 }
 
 .cardFooter > button {
-    height: clamp(34px, 8vw, 44px) !important;
-    width: clamp(34px, 8vw, 44px) !important;
-    flex: 0 0 clamp(34px, 8vw, 44px) !important;
+    height: clamp(30px, 7vw, 38px) !important;
+    width: clamp(30px, 7vw, 38px) !important;
+    flex: 0 0 clamp(30px, 7vw, 38px) !important;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -44,7 +44,7 @@
 }
 
 .title {
-    font-size: clamp(0.9rem, 0.3rem + 3.8vw, 1.8rem);
+    font-size: clamp(0.9rem, 0.35rem + 3.1vw, 1.5rem);
     font-weight: 700;
     color: #1E1E1E;
     line-height: 1.5;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -168,7 +168,7 @@ export const SpotCard = ({
                     もっと詳しく
                 </a>
                 <a 
-                    className={btnStyles.routeBtn}
+                    className={`${btnStyles.routeBtn} ${styles.routeBtn}`}
                     href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(spotName)}`}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -176,11 +176,11 @@ export const SpotCard = ({
                     ルートを見る
                 </a>
                 <button 
-                    className={btnStyles.heartBtn}
+                    className={`${btnStyles.heartBtn} ${styles.heartBtn}`}
                     onClick={onFavoriteToggle}
                 >
                     <Heart 
-                        size={18} 
+                        size={24} 
                         fill={isFavorite ? "#EF5350" : "none"} 
                         color={isFavorite ? "#EF5350" : "currentColor"} 
                     />

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -174,7 +174,7 @@ export const SpotCard = ({
                     onClick={onFavoriteToggle}
                 >
                     <Heart 
-                        size={24} 
+                        size={18} 
                         fill={isFavorite ? "#EF5350" : "none"} 
                         color={isFavorite ? "#EF5350" : "currentColor"} 
                     />

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -62,7 +62,7 @@
 /* 1行の文字の高さ（line-height 1.5想定）に合わせた高さを指定 */
 .titleSkeleton {
     width: 65%;
-    font-size: clamp(0.9rem, 0.3rem + 3.8vw, 1.8rem);
+    font-size: clamp(0.85rem, 0.4rem + 2.4vw, 1.2rem);
     height: 1.5em; 
     border-radius: 4px;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -88,7 +88,7 @@
 
 .cardImage {
     width: 100%;
-    aspect-ratio: 16 / 5;
+    aspect-ratio: 16 / 8;
 }
 
 .cardContents {
@@ -143,13 +143,13 @@
 
 .buttonSkeleton {
     flex: 1;
-    height: clamp(30px, 7vw, 38px);
+    height: clamp(34px, 8vw, 44px);
     border-radius: 9999px;
 }
 
 .heartSkeleton {
-    flex: 0 0 clamp(30px, 7vw, 38px);
-    width: clamp(30px, 7vw, 38px);
-    height: clamp(30px, 7vw, 38px);
+    flex: 0 0 clamp(34px, 8vw, 44px);
+    width: clamp(34px, 8vw, 44px);
+    height: clamp(34px, 8vw, 44px);
     border-radius: 50%;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -56,13 +56,12 @@
     margin-left: 5%;
     margin-right: auto;
     padding: 2px 0px;
-    width: 100%;
 }
 
 /* 1行の文字の高さ（line-height 1.5想定）に合わせた高さを指定 */
 .titleSkeleton {
     width: 65%;
-    font-size: clamp(0.85rem, 0.4rem + 2.4vw, 1.2rem);
+    font-size: clamp(0.9rem, 0.35rem + 3.1vw, 1.5rem);
     height: 1.5em; 
     border-radius: 4px;
 }
@@ -139,18 +138,18 @@
     padding: 0px 5% 10px 5%;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
 }
 
 .buttonSkeleton {
     flex: 1;
-    height: clamp(34px, 8vw, 44px);
+    height: clamp(30px, 7vw, 38px);
     border-radius: 9999px;
 }
 
 .heartSkeleton {
-    flex: 0 0 clamp(34px, 8vw, 44px);
-    width: clamp(34px, 8vw, 44px);
-    height: clamp(34px, 8vw, 44px);
+    flex: 0 0 clamp(30px, 7vw, 38px);
+    width: clamp(30px, 7vw, 38px);
+    height: clamp(30px, 7vw, 38px);
     border-radius: 50%;
 }

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -70,7 +70,7 @@
 .cardWrapper {
   position: absolute;
   left: 0;
-  bottom: 30px; /* 下との余白を増やして浮遊感をアップ */
+  bottom: 0px; /* 元々あったメニューバーの余白を詰め、下部にカードを下ろす */
   width: 100%;
   z-index: 10;
   transition: all 0.3s ease;


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
カードのレイアウト修正と、カードローディング時のスケルトンの調整
## 変更の理由・背景
- レイアウトの崩れを防ぎつつ、見やすくするため。

## 変更内容
- 店名の文字サイズを小さくし、2行にならないように
- ×ボタンを削除
- お気に入りボタンを下部のボタンと並べる
- ボタンの文字を小さく
- 枠線を削除し影を全方位に濃く表示 
- スケルトン を実際のカードと全く同じ大きさに修正

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 