### PR TITLE
Style: 検索バーとメニューボタンのデザイン微調整

### DIFF
--- a/miniApp/frontend/components/atoms/menuButton/MenuButton.module.css
+++ b/miniApp/frontend/components/atoms/menuButton/MenuButton.module.css
@@ -2,8 +2,8 @@
     background-color: #ffffff !important;
     opacity: 1.0 !important;
     border-radius: 13px !important;
-    width: 65px !important;
-    height: 56px !important; /* SearchTextField の高さに合わせる */
+    width: 40px !important;
+    height: 40px !important; /* SearchTextField の高さに合わせる */
     padding: 0 !important;
     box-shadow: 0 2px 6px rgba(0,0,0,0.1); /* 検索バーと同じ影を追加 */
     transition: transform 0.1s ease, background-color 0.2s ease !important;
@@ -18,7 +18,7 @@
 }
 
 .icon {
-    color: #1E1E1E !important; /* メインカラーから黒に変更 */
-    width: 35px !important;
-    height: 35px !important;
+    color: #999999 !important; /* メインカラーから黒に変更 */
+    width: 25px !important;
+    height: 25px !important;
 }

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
@@ -4,6 +4,7 @@
     height: 40px;
     background-color: #ffffff !important; /* 背景を白に */
     box-shadow: 0 2px 6px rgba(0,0,0,0.1); /* 枠線が白なので影で輪郭を出す */
+    padding-right: 3px !important;
 }
 
 /* 文字サイズ調整 */

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.module.css
@@ -1,7 +1,7 @@
 /* テキストフィールド全体のレイアウト */
 .searchField :global(.MuiOutlinedInput-root) {
     border-radius: 15px;
-    height: 56px;
+    height: 40px;
     background-color: #ffffff !important; /* 背景を白に */
     box-shadow: 0 2px 6px rgba(0,0,0,0.1); /* 枠線が白なので影で輪郭を出す */
 }
@@ -9,6 +9,8 @@
 /* 文字サイズ調整 */
 .searchField :global(.MuiOutlinedInput-input) {
     font-size: 1.1rem;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 /* 通常枠線 */
@@ -29,9 +31,9 @@
 
 /* アイコン色 */
 .icon {
-    color: var(--text-black);
-    width: 35px !important;
-    height: 35px !important;
+    color: #999999;
+    width: 24px !important;
+    height: 24px !important;
 }
 
 /* 検索ボタン */
@@ -43,6 +45,7 @@
 /* ラベルの色の調整 */
 .searchField :global(.MuiInputLabel-root) {
     color: #999999 !important; /* 灰色に固定 */
+    font-size: 0.8rem;
 }
 
 /* フォーカス時のラベルの色も灰色を維持 */
@@ -52,7 +55,7 @@
 
 /* ラベルが浮き上がらない（shrink: false）際の位置調整 */
 .searchField :global(.MuiInputLabel-root) {
-    transform: translate(14px, 16px) scale(1);
+    transform: translate(14px, 11px) scale(1);
 }
 
 /* 入力がある時にラベルを消すための補助設定（JS側でも空文字にしていますが念のため） */

--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
@@ -74,8 +74,8 @@ export const SearchTextField = ({ onSearch, onFocus, onBlur, label = "検索" }:
                   className={styles.searchButton}
                 >
                   <Search
-                    size={50}
-                    strokeWidth={3}
+                    size={24}
+                    strokeWidth={2.5}
                     className={styles.icon}
                   />
                 </IconButton>

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -15,7 +15,7 @@
   top: 16px;
   left: 50%;
   transform: translateX(-50%);
-  width: 95%;
+  width: 90%;
   max-width: 600px;
   z-index: 100;
   display: flex;


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
検索バーとメニューボタンのデザイン微調整

## 変更内容
- 検索バーとメニューボタンの高さを40pxに統一し、コンパクトなレイアウトに変更
- アイコンのサイズを縮小し、カラーをグレー（#999999）に調整
- 検索バー内のラベルのフォントサイズと表示位置を微調整
- マップ上の検索バーコンテナの横幅を90%に変更

## スクリーンショット（UI変更がある場合）
<img width="372" height="60" alt="image" src="https://github.com/user-attachments/assets/bc2b4e27-5fdb-4095-9bce-82e2c8edb813" />

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 