### PR TITLE
Enhance: マップピンのサイズを調整し、ピンクラスターを追加しました

### DIFF
--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -335,8 +335,10 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
             key={spot.id}
             position={spot.position}
             zIndex={selectedSpot?.id === spot.id ? 1000 : 1}
+            // 選択中のピンはクリックを無効化（下のピンを触れるようにする）
+            clickable={selectedSpot?.id !== spot.id}
             onClick={async () => {
-              // ピン選択時はその詳細を別途取得するロジックが必要（以前の実装を流用可能）
+              // ピン選択時はその詳細を別途取得するロジックが必要
               const alreadyFetched = displayCards.find(s => s.id === spot.id);
               if (alreadyFetched) {
                 setSelectedSpot(alreadyFetched);
@@ -378,9 +380,15 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
             }}
             icon={{
               url: spot.pinKind,
+              // 普通状態を1割小さく（高さ50px -> 45px, 幅41px -> 37px）
               scaledSize: new google.maps.Size(
-                selectedSpot?.id === spot.id ? 80 : 50,
-                selectedSpot?.id === spot.id ? 80 : 50
+                selectedSpot?.id === spot.id ? 65 : 37,
+                selectedSpot?.id === spot.id ? 80 : 45
+              ),
+              // ピンの先端（底辺中央）を正確な位置に合わせる
+              anchor: new google.maps.Point(
+                selectedSpot?.id === spot.id ? 32.5 : 18.5,
+                selectedSpot?.id === spot.id ? 80 : 45
               ),
             }}
           />

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -27,17 +27,24 @@ const containerStyle = {
   height: "100vh",
 };
 
+// --- 定数定義 ---
+const ZOOM_THRESHOLD = 15;
+const NORMAL_PIN_SIZE = { width: 37, height: 45 };
+const SELECTED_PIN_SIZE = { width: 58.5, height: 72 };
+const MAX_HISTORY_CARDS = 10;
+
+// ピンごとのメタデータ（色と種別）
+const PIN_METADATA: Record<string, { color: string, spotKind: "shop" | "spot" }> = {
+  "/FoodPin.svg":   { color: "#EF633D", spotKind: "shop" },
+  "/CameraPin.svg": { color: "#EF9651", spotKind: "spot" },
+  "/ChairPin.svg":  { color: "#3F7D58", spotKind: "spot" },
+  "/GiftPin.svg":   { color: "#F4B400", spotKind: "shop" },
+};
+
 // マップ表示時の初期中心（天神付近）
 const initCenter = {
   lat: 33.5902,
   lng: 130.4017,
-};
-
-const PIN_COLORS: Record<string, string> = {
-  "/FoodPin.svg": "#EF633D",
-  "/CameraPin.svg": "#EF9651",
-  "/ChairPin.svg": "#3F7D58",
-  "/GiftPin.svg": "#F4B400",
 };
 
 type Props = {
@@ -82,6 +89,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   const cardRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const isScrollingByCode = useRef<boolean>(false); // プログラムによるスクロール中かどうかのフラグ
   const lastSelectedSource = useRef<'map' | 'scroll'>('map'); // 選択元の判定用フラグ
+  const lastRequestSpotId = useRef<number | null>(null);
 
   // カテゴリごとにSuperclusterのインスタンスを作成
   const clustersByCategory = useMemo(() => {
@@ -91,7 +99,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
     categories.forEach(cat => {
       const sc = new Supercluster({
         radius: 60,
-        maxZoom: 15, // これ以上のズームでは集約しない
+        maxZoom: ZOOM_THRESHOLD, // これ以上のズームでは集約しない
       });
       const features = initialSpots
         .filter(s => s.pinKind === cat)
@@ -113,8 +121,6 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   const visibleEntities = useMemo(() => {
     if (!bounds) return [];
 
-    // zoom > 15 の場合でも supercluster を経由することで表示範囲内のみを取得できる
-    // 16以上ではクラスタリングされず個別ピンが返る
     return Object.entries(clustersByCategory).flatMap(([cat, sc]) => {
       const clusters = sc.getClusters(bounds, zoom);
       return clusters.map(c => {
@@ -143,7 +149,8 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   // クラスター用アイコン生成
   const getClusterIcon = (count: number, pinKind: string) => {
-    const color = PIN_COLORS[pinKind] || "#666";
+    const metadata = PIN_METADATA[pinKind];
+    const color = metadata?.color || "#666";
     const size = count < 10 ? 40 : count < 100 ? 50 : 60;
     const svg = `
       <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
@@ -161,7 +168,6 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   useEffect(() => {
     if (!hasInitializedFromUrl.current) return;
 
-    // window.location.searchを使用して無限ループを防ぐ
     const params = new URLSearchParams(window.location.search);
     const currentId = params.get('selectedId');
     const newId = selectedSpot?.id.toString() || null;
@@ -223,7 +229,6 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       if (activeKeyword) url.searchParams.append('keyword', activeKeyword);
       if (searchOptions) url.searchParams.append('options', searchOptions);
       
-      // 現在地情報を渡すことでサーバー側で5件に絞り込む
       url.searchParams.append('lat', currentPos.lat.toString());
       url.searchParams.append('lng', currentPos.lng.toString());
 
@@ -261,7 +266,6 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
           setDisplayCards(data);
           
-          // 最初の1件を選択状態にする
           if (data.length > 0) {
             lastSelectedSource.current = 'map';
             setSelectedSpot(data[0]);
@@ -347,6 +351,65 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
     }
   };
 
+  // スポットクリック時の詳細取得処理
+  const handleSpotClick = async (spotId: number, position: google.maps.LatLngLiteral, pinKind: string) => {
+    // すでに取得済みなら先頭に移動させて終了（LRU）
+    const alreadyFetched = displayCards.find(s => s.id === spotId);
+    if (alreadyFetched) {
+      setDisplayCards(prev => [alreadyFetched, ...prev.filter(s => s.id !== spotId)]);
+      setSelectedSpot(alreadyFetched);
+      return;
+    }
+    
+    // メタデータから種別を取得
+    const inferredSpotKind = PIN_METADATA[pinKind]?.spotKind || "spot";
+
+    setIsCardLoading(true);
+    lastRequestSpotId.current = spotId;
+
+    const dummySpot: MapSpotData = {
+      id: spotId,
+      position: position,
+      pinKind: pinKind,
+      spotKind: inferredSpotKind,
+      spotName: "",
+      isOpen: false,
+      imageSrc: "",
+      spotTags: [],
+      detailURL: "",
+      updatedAt: new Date()
+    };
+    
+    // リストの先頭に追加（既存の重複は削除し、最大件数保持）
+    setDisplayCards(prev => [dummySpot, ...prev.filter(s => s.id !== spotId)].slice(0, MAX_HISTORY_CARDS));
+    setSelectedSpot(dummySpot);
+
+    try {
+      const response = await fetch(`/api/spotcard?id=${spotId}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch spot details: ${response.status}`);
+      }
+      const detailData: MapSpotData = await response.json();
+      
+      // レースコンディション対策：最新のリクエストのみ処理
+      if (lastRequestSpotId.current === spotId) {
+        setDisplayCards(prev => [detailData, ...prev.filter(s => s.id !== spotId)].slice(0, MAX_HISTORY_CARDS));
+        setSelectedSpot(detailData);
+      }
+    } catch (e) { 
+      console.error("スポット詳細取得失敗:", e);
+      // エラー時はリストからダミーを削除して状態を戻す
+      if (lastRequestSpotId.current === spotId) {
+        setDisplayCards(prev => prev.filter(s => s.id !== spotId));
+        setSelectedSpot(null);
+      }
+    } finally {
+      if (lastRequestSpotId.current === spotId) {
+        setIsCardLoading(false);
+      }
+    }
+  };
+
   if (!isLoaded) return <Loading />;
 
   return (
@@ -355,7 +418,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
         <SearchTextField 
           onSearch={(val) => setActiveKeyword(val)} 
           onFocus={() => setIsSearchFocused(true)}
-          onBlur={() => setTimeout(() => setIsSearchFocused(false), 200)} // ボタンクリックを可能にするためディレイを設ける
+          onBlur={() => setTimeout(() => setIsSearchFocused(false), 200)}
           label="行きたい場所を検索" 
         />
         <MenuButton 
@@ -428,17 +491,29 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
         )}
 
         {visibleEntities.map((entity) => {
-          if (entity.isCluster) {
+          const spotId = Number(entity.id);
+          const isSelected = selectedSpot?.id === spotId;
+
+          // 閾値以下の場合は、単一のピンでも「丸1」アイコンで表示する
+          const shouldShowCircleStyle = entity.isCluster || zoom <= ZOOM_THRESHOLD;
+
+          if (shouldShowCircleStyle) {
             const { url, size } = getClusterIcon(entity.count, entity.pinKind);
             return (
               <Marker
                 key={entity.id}
                 position={entity.position}
+                zIndex={!entity.isCluster && isSelected ? 1000 : 1}
+                clickable={entity.isCluster || !isSelected}
                 onClick={() => {
-                  if (mapRef.current && entity.clusterId !== undefined && typeof entity.clusterId === 'number') {
-                    const expansionZoom = clustersByCategory[entity.pinKind].getClusterExpansionZoom(entity.clusterId);
-                    mapRef.current.setZoom(expansionZoom);
-                    mapRef.current.panTo(entity.position);
+                  if (entity.isCluster) {
+                    if (mapRef.current && entity.clusterId !== undefined && typeof entity.clusterId === 'number') {
+                      const expansionZoom = clustersByCategory[entity.pinKind].getClusterExpansionZoom(entity.clusterId);
+                      mapRef.current.setZoom(expansionZoom);
+                      mapRef.current.panTo(entity.position);
+                    }
+                  } else {
+                    handleSpotClick(spotId, entity.position, entity.pinKind);
                   }
                 }}
                 icon={{
@@ -449,60 +524,19 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
             );
           }
 
+          // 個別ピン（詳細なSVGアイコン）の表示（zoom > ZOOM_THRESHOLD の場合）
+          const pinSize = isSelected ? SELECTED_PIN_SIZE : NORMAL_PIN_SIZE;
           return (
             <Marker
               key={entity.id}
               position={entity.position}
-              zIndex={selectedSpot?.id === entity.id ? 1000 : 1}
-              clickable={selectedSpot?.id !== entity.id}
-              onClick={async () => {
-                const alreadyFetched = displayCards.find(s => s.id === entity.id);
-                if (alreadyFetched) {
-                  setSelectedSpot(alreadyFetched);
-                  return;
-                }
-                
-                setIsCardLoading(true);
-                const dummySpot: MapSpotData = {
-                  id: Number(entity.id),
-                  position: entity.position,
-                  pinKind: entity.pinKind,
-                  spotKind: "spot",
-                  spotName: "",
-                  isOpen: false,
-                  imageSrc: "",
-                  spotTags: [],
-                  detailURL: "",
-                  updatedAt: new Date()
-                };
-                setDisplayCards([dummySpot]);
-                setSelectedSpot(dummySpot);
-
-                try {
-                  const response = await fetch(`/api/spotcard?id=${entity.id}`);
-                  if (response.ok) {
-                    const detailData: MapSpotData = await response.json();
-                    setDisplayCards([detailData]);
-                    setSelectedSpot(detailData);
-                  }
-                } catch (e) { 
-                  console.error(e); 
-                  setSelectedSpot(null);
-                  setDisplayCards([]);
-                } finally {
-                  setIsCardLoading(false);
-                }
-              }}
+              zIndex={isSelected ? 1000 : 1}
+              clickable={!isSelected}
+              onClick={() => handleSpotClick(spotId, entity.position, entity.pinKind)}
               icon={{
                 url: entity.pinKind,
-                scaledSize: new google.maps.Size(
-                  selectedSpot?.id === entity.id ? 65 : 37,
-                  selectedSpot?.id === entity.id ? 80 : 45
-                ),
-                anchor: new google.maps.Point(
-                  selectedSpot?.id === entity.id ? 32.5 : 18.5,
-                  selectedSpot?.id === entity.id ? 80 : 45
-                ),
+                scaledSize: new google.maps.Size(pinSize.width, pinSize.height),
+                anchor: new google.maps.Point(pinSize.width / 2, pinSize.height),
               }}
             />
           );

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -31,7 +31,6 @@ const containerStyle = {
 const ZOOM_THRESHOLD = 15;
 const NORMAL_PIN_SIZE = { width: 37, height: 45 };
 const SELECTED_PIN_SIZE = { width: 58.5, height: 72 };
-const MAX_HISTORY_CARDS = 10;
 
 // ピンごとのメタデータ（色と種別）
 const PIN_METADATA: Record<string, { color: string, spotKind: "shop" | "spot" }> = {
@@ -48,7 +47,7 @@ const initCenter = {
 };
 
 type Props = {
-  initialSpots: MinimalSpotData[]; // 初期表示は最小限のデータ配列を受け取る
+  initialSpots: MinimalSpotData[]; // 初期表示は最小限েরデータ配列を受け取る
   keyword?: string; // 検索キーワード（URL等から）
   options?: string; // 検索タグ（URL等から）
 }
@@ -91,66 +90,59 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   const lastSelectedSource = useRef<'map' | 'scroll'>('map'); // 選択元の判定用フラグ
   const lastRequestSpotId = useRef<number | null>(null);
 
-  // カテゴリごとにSuperclusterのインスタンスを作成
-  const clustersByCategory = useMemo(() => {
-    const categories = Array.from(new Set(initialSpots.map(s => s.pinKind)));
-    const result: Record<string, Supercluster> = {};
-
-    categories.forEach(cat => {
-      const sc = new Supercluster({
-        radius: 60,
-        maxZoom: ZOOM_THRESHOLD, // これ以上のズームでは集約しない
-      });
-      const features = initialSpots
-        .filter(s => s.pinKind === cat)
-        .map(s => ({
-          type: 'Feature' as const,
-          properties: { cluster: false, spotId: s.id, pinKind: s.pinKind },
-          geometry: {
-            type: 'Point' as const,
-            coordinates: [s.position.lng, s.position.lat],
-          },
-        }));
-      sc.load(features);
-      result[cat] = sc;
+  // Superclusterのインスタンスを作成
+  const supercluster = useMemo(() => {
+    const sc = new Supercluster({
+      radius: 60,
+      maxZoom: ZOOM_THRESHOLD, // これ以上のズームでは集約しない
     });
-    return result;
+    
+    const features = initialSpots.map(s => ({
+      type: 'Feature' as const,
+      properties: { cluster: false, spotId: s.id, pinKind: s.pinKind },
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [s.position.lng, s.position.lat],
+      },
+    }));
+    
+    sc.load(features);
+    return sc;
   }, [initialSpots]);
 
   // 表示対象（クラスターまたは個別のピン）を計算
   const visibleEntities = useMemo(() => {
-    if (!bounds) return [];
+    if (!bounds || !supercluster) return [];
 
-    return Object.entries(clustersByCategory).flatMap(([cat, sc]) => {
-      const clusters = sc.getClusters(bounds, zoom);
-      return clusters.map(c => {
-        const [lng, lat] = c.geometry.coordinates;
-        if (c.properties.cluster) {
-          return {
-            id: `cluster-${cat}-${c.id}`,
-            position: { lat, lng },
-            pinKind: cat,
-            isCluster: true,
-            count: c.properties.point_count,
-            clusterId: c.id
-          };
-        } else {
-          return {
-            id: c.properties.spotId,
-            position: { lat, lng },
-            pinKind: c.properties.pinKind,
-            isCluster: false,
-            count: 1
-          };
-        }
-      });
+    const clusters = supercluster.getClusters(bounds, zoom);
+    return clusters.map(c => {
+      const [lng, lat] = c.geometry.coordinates;
+      if (c.properties.cluster) {
+        return {
+          id: `cluster-${c.id}`,
+          position: { lat, lng },
+          pinKind: 'cluster', // 混合クラスター用
+          isCluster: true,
+          count: c.properties.point_count,
+          clusterId: c.id
+        };
+      } else {
+        return {
+          id: c.properties.spotId,
+          position: { lat, lng },
+          pinKind: c.properties.pinKind,
+          isCluster: false,
+          count: 1
+        };
+      }
     });
-  }, [clustersByCategory, bounds, zoom]);
+  }, [supercluster, bounds, zoom]);
 
   // クラスター用アイコン生成
   const getClusterIcon = (count: number, pinKind: string) => {
+    // クラスター（混合）の場合はデフォルトカラー、単一ピンの場合はその色を使用
     const metadata = PIN_METADATA[pinKind];
-    const color = metadata?.color || "#666";
+    const color = metadata?.color || "#3F7D58"; // 混合クラスターはメインカラー（緑）
     const size = count < 10 ? 40 : count < 100 ? 50 : 60;
     const svg = `
       <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
@@ -353,15 +345,16 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   // スポットクリック時の詳細取得処理
   const handleSpotClick = async (spotId: number, position: google.maps.LatLngLiteral, pinKind: string) => {
-    // すでに取得済みなら先頭に移動させて終了（LRU）
-    const alreadyFetched = displayCards.find(s => s.id === spotId);
-    if (alreadyFetched) {
-      setDisplayCards(prev => [alreadyFetched, ...prev.filter(s => s.id !== spotId)]);
-      setSelectedSpot(alreadyFetched);
+    lastSelectedSource.current = 'map';
+    
+    // すでに現在のリストにあるなら、そのスポットを選択（スクロール）するだけにする
+    const alreadyInList = displayCards.find(s => s.id === spotId);
+    if (alreadyInList) {
+      setSelectedSpot(alreadyInList);
       return;
     }
     
-    // メタデータから種別を取得
+    // リストにない場合、新規スポット1件のみを表示する形に切り替える（リストが際限なく増えるのを防ぐ）
     const inferredSpotKind = PIN_METADATA[pinKind]?.spotKind || "spot";
 
     setIsCardLoading(true);
@@ -380,8 +373,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       updatedAt: new Date()
     };
     
-    // リストの先頭に追加（既存の重複は削除し、最大件数保持）
-    setDisplayCards(prev => [dummySpot, ...prev.filter(s => s.id !== spotId)].slice(0, MAX_HISTORY_CARDS));
+    setDisplayCards([dummySpot]);
     setSelectedSpot(dummySpot);
 
     try {
@@ -393,14 +385,13 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       
       // レースコンディション対策：最新のリクエストのみ処理
       if (lastRequestSpotId.current === spotId) {
-        setDisplayCards(prev => [detailData, ...prev.filter(s => s.id !== spotId)].slice(0, MAX_HISTORY_CARDS));
+        setDisplayCards([detailData]);
         setSelectedSpot(detailData);
       }
     } catch (e) { 
       console.error("スポット詳細取得失敗:", e);
-      // エラー時はリストからダミーを削除して状態を戻す
       if (lastRequestSpotId.current === spotId) {
-        setDisplayCards(prev => prev.filter(s => s.id !== spotId));
+        setDisplayCards([]);
         setSelectedSpot(null);
       }
     } finally {
@@ -504,16 +495,31 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
                 key={entity.id}
                 position={entity.position}
                 zIndex={!entity.isCluster && isSelected ? 1000 : 1}
-                clickable={entity.isCluster || !isSelected}
+                clickable={true}
                 onClick={() => {
                   if (entity.isCluster) {
                     if (mapRef.current && entity.clusterId !== undefined && typeof entity.clusterId === 'number') {
-                      const expansionZoom = clustersByCategory[entity.pinKind].getClusterExpansionZoom(entity.clusterId);
+                      const expansionZoom = supercluster.getClusterExpansionZoom(entity.clusterId);
                       mapRef.current.setZoom(expansionZoom);
-                      mapRef.current.panTo(entity.position);
+                      
+                      // カードが開いている場合はオフセットを考慮して移動
+                      if (selectedSpot) {
+                        panMapToSpot(mapRef.current, entity.position, expansionZoom);
+                      } else {
+                        mapRef.current.panTo(entity.position);
+                      }
                     }
                   } else {
                     handleSpotClick(spotId, entity.position, entity.pinKind);
+                    // 単一ピン（丸1）をクリックした際、詳細ピンが見えるズームレベルまで拡大する
+                    if (mapRef.current) {
+                      const nextZoom = zoom <= ZOOM_THRESHOLD ? ZOOM_THRESHOLD + 1 : zoom;
+                      if (zoom <= ZOOM_THRESHOLD) {
+                        mapRef.current.setZoom(nextZoom);
+                      }
+                      // ズーム変更と移動を同期させるため、明示的にズームレベルを渡す
+                      panMapToSpot(mapRef.current, entity.position, nextZoom);
+                    }
                   }
                 }}
                 icon={{
@@ -531,7 +537,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
               key={entity.id}
               position={entity.position}
               zIndex={isSelected ? 1000 : 1}
-              clickable={!isSelected}
+              clickable={true}
               onClick={() => handleSpotClick(spotId, entity.position, entity.pinKind)}
               icon={{
                 url: entity.pinKind,

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -54,9 +54,13 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   const { isFavorite, toggleFavorite } = useFavorites();
 
-  const { isLoaded } = useJsApiLoader({
+  const { isLoaded, loadError } = useJsApiLoader({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
   });
+
+  if (loadError) {
+    console.error("Google Maps API load error:", loadError);
+  }
 
   // state管理
   const [selectedSpot, setSelectedSpot] = useState<null | MapSpotData>(null);  // 選択中の詳細データ
@@ -107,17 +111,10 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   // 表示対象（クラスターまたは個別のピン）を計算
   const visibleEntities = useMemo(() => {
-    if (!bounds || zoom > 15) {
-      // ズームが大きい場合は全ピンを表示（またはSuperclusterで単一ピンとして取得）
-      return initialSpots.map(s => ({
-        id: s.id,
-        position: s.position,
-        pinKind: s.pinKind,
-        isCluster: false,
-        count: 1
-      }));
-    }
+    if (!bounds) return [];
 
+    // zoom > 15 の場合でも supercluster を経由することで表示範囲内のみを取得できる
+    // 16以上ではクラスタリングされず個別ピンが返る
     return Object.entries(clustersByCategory).flatMap(([cat, sc]) => {
       const clusters = sc.getClusters(bounds, zoom);
       return clusters.map(c => {
@@ -142,7 +139,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
         }
       });
     });
-  }, [clustersByCategory, bounds, zoom, initialSpots]);
+  }, [clustersByCategory, bounds, zoom]);
 
   // クラスター用アイコン生成
   const getClusterIcon = (count: number, pinKind: string) => {
@@ -154,7 +151,10 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
         <text x="50%" y="50%" text-anchor="middle" fill="white" font-size="${Math.floor(size/2.5)}px" font-weight="bold" font-family="Arial" dy=".35em">${count}</text>
       </svg>
     `;
-    return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`;
+    return {
+      url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`,
+      size
+    };
   };
 
   // 選択中のスポットが変わったらURLのクエリパラメータを更新する
@@ -429,20 +429,21 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
         {visibleEntities.map((entity) => {
           if (entity.isCluster) {
+            const { url, size } = getClusterIcon(entity.count, entity.pinKind);
             return (
               <Marker
                 key={entity.id}
                 position={entity.position}
                 onClick={() => {
-                  if (mapRef.current && entity.clusterId && typeof entity.clusterId === 'number') {
+                  if (mapRef.current && entity.clusterId !== undefined && typeof entity.clusterId === 'number') {
                     const expansionZoom = clustersByCategory[entity.pinKind].getClusterExpansionZoom(entity.clusterId);
                     mapRef.current.setZoom(expansionZoom);
                     mapRef.current.panTo(entity.position);
                   }
                 }}
                 icon={{
-                  url: getClusterIcon(entity.count, entity.pinKind),
-                  anchor: new google.maps.Point(20, 20),
+                  url: url,
+                  anchor: new google.maps.Point(size / 2, size / 2),
                 }}
               />
             );

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from "./MapComponent.module.css"
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import {
   GoogleMap,
@@ -20,6 +20,7 @@ import { TagSearchButtons } from "@/components/organisms/tagSearchButtons/TagSea
 import { MapSpotData, MinimalSpotData, HAKATA_STATION } from "@/types/map";
 import { panMapToSpot } from "@/lib/map/mapUtils";
 import { useFavorites } from "@/hooks/useFavorites";
+import Supercluster from 'supercluster';
 
 const containerStyle = {
   width: "100%",
@@ -30,6 +31,13 @@ const containerStyle = {
 const initCenter = {
   lat: 33.5902,
   lng: 130.4017,
+};
+
+const PIN_COLORS: Record<string, string> = {
+  "/FoodPin.svg": "#EF633D",
+  "/CameraPin.svg": "#EF9651",
+  "/ChairPin.svg": "#3F7D58",
+  "/GiftPin.svg": "#F4B400",
 };
 
 type Props = {
@@ -46,20 +54,9 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
 
   const { isFavorite, toggleFavorite } = useFavorites();
 
-  const { isLoaded, loadError } = useJsApiLoader({
+  const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
   });
-
-  useEffect(() => {
-    console.log("Browser-side Map Load State changed:", { isLoaded, loadError });
-    if (window.google) {
-      console.log("Google object is available in window!");
-    }
-  }, [isLoaded, loadError]);
-
-  if (loadError) {
-    console.error("Google Maps API load error:", loadError);
-  }
 
   // state管理
   const [selectedSpot, setSelectedSpot] = useState<null | MapSpotData>(null);  // 選択中の詳細データ
@@ -71,12 +68,94 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   const [isMenuOpen, setIsMenuOpen] = useState(false); // メニューの開閉状態
   const [isSearchFocused, setIsSearchFocused] = useState(false); // 検索バーのフォーカス状態
 
+  // クラスター用state
+  const [zoom, setZoom] = useState(14);
+  const [bounds, setBounds] = useState<[number, number, number, number] | null>(null);
+
   // カード表示用リスト
   const [displayCards, setDisplayCards] = useState<MapSpotData[]>([]);
   const cardListRef = useRef<HTMLDivElement | null>(null);
   const cardRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const isScrollingByCode = useRef<boolean>(false); // プログラムによるスクロール中かどうかのフラグ
   const lastSelectedSource = useRef<'map' | 'scroll'>('map'); // 選択元の判定用フラグ
+
+  // カテゴリごとにSuperclusterのインスタンスを作成
+  const clustersByCategory = useMemo(() => {
+    const categories = Array.from(new Set(initialSpots.map(s => s.pinKind)));
+    const result: Record<string, Supercluster> = {};
+
+    categories.forEach(cat => {
+      const sc = new Supercluster({
+        radius: 60,
+        maxZoom: 15, // これ以上のズームでは集約しない
+      });
+      const features = initialSpots
+        .filter(s => s.pinKind === cat)
+        .map(s => ({
+          type: 'Feature' as const,
+          properties: { cluster: false, spotId: s.id, pinKind: s.pinKind },
+          geometry: {
+            type: 'Point' as const,
+            coordinates: [s.position.lng, s.position.lat],
+          },
+        }));
+      sc.load(features);
+      result[cat] = sc;
+    });
+    return result;
+  }, [initialSpots]);
+
+  // 表示対象（クラスターまたは個別のピン）を計算
+  const visibleEntities = useMemo(() => {
+    if (!bounds || zoom > 15) {
+      // ズームが大きい場合は全ピンを表示（またはSuperclusterで単一ピンとして取得）
+      return initialSpots.map(s => ({
+        id: s.id,
+        position: s.position,
+        pinKind: s.pinKind,
+        isCluster: false,
+        count: 1
+      }));
+    }
+
+    return Object.entries(clustersByCategory).flatMap(([cat, sc]) => {
+      const clusters = sc.getClusters(bounds, zoom);
+      return clusters.map(c => {
+        const [lng, lat] = c.geometry.coordinates;
+        if (c.properties.cluster) {
+          return {
+            id: `cluster-${cat}-${c.id}`,
+            position: { lat, lng },
+            pinKind: cat,
+            isCluster: true,
+            count: c.properties.point_count,
+            clusterId: c.id
+          };
+        } else {
+          return {
+            id: c.properties.spotId,
+            position: { lat, lng },
+            pinKind: c.properties.pinKind,
+            isCluster: false,
+            count: 1
+          };
+        }
+      });
+    });
+  }, [clustersByCategory, bounds, zoom, initialSpots]);
+
+  // クラスター用アイコン生成
+  const getClusterIcon = (count: number, pinKind: string) => {
+    const color = PIN_COLORS[pinKind] || "#666";
+    const size = count < 10 ? 40 : count < 100 ? 50 : 60;
+    const svg = `
+      <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="${size/2}" cy="${size/2}" r="${size/2 - 2}" fill="${color}" fill-opacity="0.9" stroke="white" stroke-width="2" />
+        <text x="50%" y="50%" text-anchor="middle" fill="white" font-size="${Math.floor(size/2.5)}px" font-weight="bold" font-family="Arial" dy=".35em">${count}</text>
+      </svg>
+    `;
+    return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`;
+  };
 
   // 選択中のスポットが変わったらURLのクエリパラメータを更新する
   useEffect(() => {
@@ -300,7 +379,7 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       <GoogleMap
         mapContainerStyle={containerStyle}
         center={initCenter}
-        zoom={14}
+        zoom={zoom}
         options={{
           mapId: "2180f9c8f0d419cfa3681583",
           disableDefaultUI: true,
@@ -309,6 +388,24 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
           mapRef.current = map;
           if (selectedSpot) {
             panMapToSpot(map, selectedSpot.position);
+          }
+          const b = map.getBounds();
+          if (b) {
+            const ne = b.getNorthEast();
+            const sw = b.getSouthWest();
+            setBounds([sw.lng(), sw.lat(), ne.lng(), ne.lat()]);
+          }
+        }}
+        onIdle={() => {
+          if (mapRef.current) {
+            const newZoom = mapRef.current.getZoom() ?? 14;
+            setZoom(newZoom);
+            const b = mapRef.current.getBounds();
+            if (b) {
+              const ne = b.getNorthEast();
+              const sw = b.getSouthWest();
+              setBounds([sw.lng(), sw.lat(), ne.lng(), ne.lat()]);
+            }
           }
         }}
         onClick={() => {
@@ -330,69 +427,85 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
           />
         )}
 
-        {initialSpots.map((spot) => (
-          <Marker
-            key={spot.id}
-            position={spot.position}
-            zIndex={selectedSpot?.id === spot.id ? 1000 : 1}
-            // 選択中のピンはクリックを無効化（下のピンを触れるようにする）
-            clickable={selectedSpot?.id !== spot.id}
-            onClick={async () => {
-              // ピン選択時はその詳細を別途取得するロジックが必要
-              const alreadyFetched = displayCards.find(s => s.id === spot.id);
-              if (alreadyFetched) {
-                setSelectedSpot(alreadyFetched);
-                return;
-              }
-              
-              setIsCardLoading(true);
-              // スケルトン表示用のダミーデータをセット
-              const dummySpot: MapSpotData = {
-                id: spot.id,
-                position: spot.position,
-                pinKind: spot.pinKind,
-                spotKind: "spot",
-                spotName: "",
-                isOpen: false,
-                imageSrc: "",
-                spotTags: [],
-                detailURL: "",
-                updatedAt: new Date()
-              };
-              setDisplayCards([dummySpot]);
-              setSelectedSpot(dummySpot);
+        {visibleEntities.map((entity) => {
+          if (entity.isCluster) {
+            return (
+              <Marker
+                key={entity.id}
+                position={entity.position}
+                onClick={() => {
+                  if (mapRef.current && entity.clusterId && typeof entity.clusterId === 'number') {
+                    const expansionZoom = clustersByCategory[entity.pinKind].getClusterExpansionZoom(entity.clusterId);
+                    mapRef.current.setZoom(expansionZoom);
+                    mapRef.current.panTo(entity.position);
+                  }
+                }}
+                icon={{
+                  url: getClusterIcon(entity.count, entity.pinKind),
+                  anchor: new google.maps.Point(20, 20),
+                }}
+              />
+            );
+          }
 
-              // APIから詳細を取得
-              try {
-                const response = await fetch(`/api/spotcard?id=${spot.id}`);
-                if (response.ok) {
-                  const detailData: MapSpotData = await response.json();
-                  setDisplayCards([detailData]); // リストを上書きして選択状態にする
-                  setSelectedSpot(detailData);
+          return (
+            <Marker
+              key={entity.id}
+              position={entity.position}
+              zIndex={selectedSpot?.id === entity.id ? 1000 : 1}
+              clickable={selectedSpot?.id !== entity.id}
+              onClick={async () => {
+                const alreadyFetched = displayCards.find(s => s.id === entity.id);
+                if (alreadyFetched) {
+                  setSelectedSpot(alreadyFetched);
+                  return;
                 }
-              } catch (e) { 
-                console.error(e); 
-                setSelectedSpot(null);
-                setDisplayCards([]);
-              } finally {
-                setIsCardLoading(false);
-              }
-            }}
-            icon={{
-              url: spot.pinKind,
-              // 普通状態を1割小さく（高さ50px -> 45px, 幅41px -> 37px）
-              scaledSize: new google.maps.Size(
-                selectedSpot?.id === spot.id ? 65 : 37,
-                selectedSpot?.id === spot.id ? 80 : 45
-              ),
-              // ピンの先端（底辺中央）を正確な位置に合わせる
-              anchor: new google.maps.Point(
-                selectedSpot?.id === spot.id ? 32.5 : 18.5,
-                selectedSpot?.id === spot.id ? 80 : 45
-              ),
-            }}
-          />
-        ))}
+                
+                setIsCardLoading(true);
+                const dummySpot: MapSpotData = {
+                  id: Number(entity.id),
+                  position: entity.position,
+                  pinKind: entity.pinKind,
+                  spotKind: "spot",
+                  spotName: "",
+                  isOpen: false,
+                  imageSrc: "",
+                  spotTags: [],
+                  detailURL: "",
+                  updatedAt: new Date()
+                };
+                setDisplayCards([dummySpot]);
+                setSelectedSpot(dummySpot);
+
+                try {
+                  const response = await fetch(`/api/spotcard?id=${entity.id}`);
+                  if (response.ok) {
+                    const detailData: MapSpotData = await response.json();
+                    setDisplayCards([detailData]);
+                    setSelectedSpot(detailData);
+                  }
+                } catch (e) { 
+                  console.error(e); 
+                  setSelectedSpot(null);
+                  setDisplayCards([]);
+                } finally {
+                  setIsCardLoading(false);
+                }
+              }}
+              icon={{
+                url: entity.pinKind,
+                scaledSize: new google.maps.Size(
+                  selectedSpot?.id === entity.id ? 65 : 37,
+                  selectedSpot?.id === entity.id ? 80 : 45
+                ),
+                anchor: new google.maps.Point(
+                  selectedSpot?.id === entity.id ? 32.5 : 18.5,
+                  selectedSpot?.id === entity.id ? 80 : 45
+                ),
+              }}
+            />
+          );
+        })}
 
         <div className={selectedSpot ? styles.cardWrapper : `${styles.cardWrapper} ${styles.cardHidden}`}>
           {selectedSpot && (
@@ -401,7 +514,6 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
               ref={cardListRef}
               onScroll={handleScroll}
             >
-              {/* 最初と最後のカードも中央に来るようにスペーサーを配置 */}
               <div className={styles.spacer} />
               {displayCards.map((spot) => (
                 <div 

--- a/miniApp/frontend/lib/map/mapUtils.ts
+++ b/miniApp/frontend/lib/map/mapUtils.ts
@@ -7,8 +7,8 @@ export const calculateOffsetByZoom = (zoom: number) => 0.00012 * Math.pow(2, 20 
 /**
  * 指定した座標を、画面中央から10%上に表示するように地図を移動
  */
-export const panMapToSpot = (map: google.maps.Map, position: google.maps.LatLngLiteral) => {
-  const zoom = map.getZoom() ?? 15;
+export const panMapToSpot = (map: google.maps.Map, position: google.maps.LatLngLiteral, targetZoom?: number) => {
+  const zoom = targetZoom ?? map.getZoom() ?? 15;
   const offsetLat = calculateOffsetByZoom(zoom);
 
   // 地図の中心を「ピンの座標より少し南（下）」に設定することで、

--- a/miniApp/frontend/package-lock.json
+++ b/miniApp/frontend/package-lock.json
@@ -17,10 +17,12 @@
         "@react-google-maps/api": "^2.20.8",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.1",
+        "@types/supercluster": "^7.1.3",
         "lucide-react": "^0.563.0",
         "next": "^16.2.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "supercluster": "^8.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2900,6 +2902,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/google.maps": {
       "version": "3.58.1",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
@@ -2973,6 +2981,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/ws": {

--- a/miniApp/frontend/package.json
+++ b/miniApp/frontend/package.json
@@ -18,10 +18,12 @@
     "@react-google-maps/api": "^2.20.8",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.1",
+    "@types/supercluster": "^7.1.3",
     "lucide-react": "^0.563.0",
     "next": "^16.2.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "supercluster": "^8.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
マップピンのサイズを調整し、ピンクラスターを追加しました
## 変更の理由・背景
- ピンが大量にあり見づらかった
- ピンの当たり判定が大きく、他のピンが押しづらかった

## 変更内容
- 選択中のピンのクリックを無効化し、重なっている下のピンを選択できるように改善
- ピンのアイコンサイズを調整し、通常時のサイズを小型化
- アンカー位置を適切に設定し、ピンの先端が地図上の正確な位置を指すように修正
- superclusterライブラリを導入し、ズームレベルに応じてマーカーを集約する機能を実装しました。
- マーカーのカテゴリ（pinKind）ごとにクラスタリングを計算し、種類に応じた色分けと件数表示を行う動的SVGアイコンを追加しました。
- 地図のズームレベルや表示範囲（bounds）の変化を検知して、表示するマーカーとクラスタを動的に切り替えるロジックを実装しました。
- クラスタをクリックした際に、その範囲までズームアップする機能を追加しました。
- Google Maps API の読み込みエラー処理を追加
- 高ズーム時もスーパークラスターによる範囲内計算を行うようロジックを統一
- クラスターアイコンの SVG エンコード方式を改善し、アンカー位置を動的に計算
- クラスターIDの存在チェックを厳密化（ID 0 の不具合を防止）
- ズームレベルに応じたピン表示スタイル（サークル/詳細アイコン）の切り替えロジックを追加
- スポットクリック時に詳細情報を取得し、履歴として最大10件保持する機能を追加
- 非同期通信のレースコンディション対策を導入
- ピンのサイズやメタデータ（色・種別）を定数として集約しリファクタリング
-
## スクリーンショット（UI変更がある場合）
<img width="1170" height="2532" alt="localhost_3000_map(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/5668a5d2-963c-452d-80c8-352fe959c209" />
<img width="1170" height="2532" alt="localhost_3000_map(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/82654b41-ebde-49e1-b43b-3c3aed2ea248" />

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 