### PR TITLE
Fix: メニューのスタイルを最適化しました

### DIFF
--- a/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.module.css
+++ b/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.module.css
@@ -14,7 +14,11 @@
   font-weight: bold;
   font-size: 1.05rem;
   margin: 0;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.3;
 }
 
 .itemDesc {
@@ -71,7 +75,7 @@
   flex: 1;
   border-bottom: 1.5px dotted #ccc;
   margin: 0 8px;
-  transform: translateY(3px); /* Explicitly move the line up by 2px */
+  transform: translateY(2px); /* Centering adjustment */
 }
 
 .showMoreMenu {

--- a/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.module.css
+++ b/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.module.css
@@ -6,14 +6,6 @@
   font-weight: bold;
 }
 
-.itemImage {
-  width: 100px;
-  height: 100px;
-  background-color: #ddd;
-  border-radius: 4px;
-  object-fit: cover;
-}
-
 .itemInfo {
   flex: 1;
 }
@@ -21,19 +13,14 @@
 .itemName {
   font-weight: bold;
   font-size: 1.05rem;
-  margin-bottom: 2px;
+  margin: 0;
+  white-space: nowrap;
 }
 
 .itemDesc {
   font-size: 0.8rem;
   color: #888;
-  margin-bottom: 4px;
-}
-
-.itemPrice {
-  color: #EF633D;
-  font-weight: bold;
-  font-size: 1.1rem;
+  margin: 2px 0 0 0;
 }
 
 .menuList {
@@ -80,28 +67,6 @@
   width: 100%;
 }
 
-.itemName {
-  font-weight: bold;
-  font-size: 1.05rem;
-  margin: 0;
-  white-space: nowrap;
-}
-
-.itemDesc {
-  font-size: 0.8rem;
-  color: #888;
-  margin: 2px 0 0 0;
-}
-
-.itemPrice {
-  color: #EF633D;
-  font-weight: bold;
-  font-size: 1.1rem;
-  margin: 0;
-  white-space: nowrap;
-}
-
-
 .dots {
   flex: 1;
   border-bottom: 1.5px dotted #ccc;
@@ -121,4 +86,3 @@
   margin-bottom: 2rem;
   cursor: pointer;
 }
-

--- a/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
+++ b/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react"
 import { Menu } from '@/types/menu'
 import Image from 'next/image'
-import { formatPrice } from '@/lib/format';
+import { Price } from '../price/Price';
 
 type GeneralMenusProps = {
   GeneralMenus: Menu[];
@@ -35,7 +35,7 @@ const MenuItem = ({ item }: { item: Menu }) => {
         <div className={styles.menuItemTop}>
           <p className={styles.itemName}>{item.name}</p>
           <div className={styles.dots}></div>
-          <p className={styles.itemPrice}>¥{formatPrice(item.price)}</p>
+          <Price price={item.price} />
         </div>
         <p className={styles.itemDesc}>{item.detail}</p>
       </div>

--- a/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
+++ b/miniApp/frontend/components/atoms/generalMenus/GeneralMenus.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react"
 import { Menu } from '@/types/menu'
 import Image from 'next/image'
+import { formatPrice } from '@/lib/format';
 
 type GeneralMenusProps = {
   GeneralMenus: Menu[];
@@ -34,7 +35,7 @@ const MenuItem = ({ item }: { item: Menu }) => {
         <div className={styles.menuItemTop}>
           <p className={styles.itemName}>{item.name}</p>
           <div className={styles.dots}></div>
-          <p className={styles.itemPrice}>¥{item.price}</p>
+          <p className={styles.itemPrice}>¥{formatPrice(item.price)}</p>
         </div>
         <p className={styles.itemDesc}>{item.detail}</p>
       </div>

--- a/miniApp/frontend/components/atoms/price/Price.module.css
+++ b/miniApp/frontend/components/atoms/price/Price.module.css
@@ -1,0 +1,11 @@
+.price {
+  color: #EF633D;
+  font-weight: bold;
+  font-size: 1.1rem;
+  white-space: nowrap;
+}
+
+.currencyMark {
+  font-size: 0.85em;
+  margin-right: 1px;
+}

--- a/miniApp/frontend/components/atoms/price/Price.tsx
+++ b/miniApp/frontend/components/atoms/price/Price.tsx
@@ -1,0 +1,24 @@
+import styles from './Price.module.css';
+import { formatPrice } from '@/lib/format';
+
+interface PriceProps {
+  price: number | string | undefined | null;
+  className?: string;
+}
+
+/**
+ * 金額を表示するための共通コンポーネント
+ * 価格が存在しない場合は何もレンダリングしません。
+ */
+export const Price = ({ price, className }: PriceProps) => {
+  const formattedPrice = formatPrice(price);
+  
+  if (!formattedPrice) return null;
+
+  return (
+    <span className={`${styles.price} ${className || ''}`}>
+      <span className={styles.currencyMark} aria-hidden="true">¥</span>
+      {formattedPrice}
+    </span>
+  );
+};

--- a/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.module.css
+++ b/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.module.css
@@ -39,10 +39,3 @@
   color: #888;
   margin-bottom: 4px;
 }
-
-.itemPrice {
-  color: #EF633D;
-  font-weight: bold;
-  font-size: 1.1rem;
-}
-

--- a/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.module.css
+++ b/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.module.css
@@ -32,6 +32,11 @@
   font-size: 1.05rem;
   margin-bottom: 2px;
   margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.3;
 }
 
 .itemDesc {

--- a/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
+++ b/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
@@ -1,6 +1,7 @@
 import {Menu} from '@/types/menu'
 import styles from './RecommendMenu.module.css'
 import Image from 'next/image'
+import { formatPrice } from '@/lib/format';
 
 type recommendMenuProps = {
     recommendMenu: Menu;
@@ -26,7 +27,7 @@ export default function RecommendMenu ({ recommendMenu }: recommendMenuProps) {
             <div className={styles.itemInfo}>
                 <p className={styles.itemName}>{recommendMenu.name}</p>
                 <p className={styles.itemDesc}>{recommendMenu.detail}</p>
-                <p className={styles.itemPrice}>¥{recommendMenu.price}</p>
+                <p className={styles.itemPrice}>¥{formatPrice(recommendMenu.price)}</p>
             </div>
         </div>
     )

--- a/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
+++ b/miniApp/frontend/components/atoms/recommendMenu/RecommendMenu.tsx
@@ -1,7 +1,7 @@
 import {Menu} from '@/types/menu'
 import styles from './RecommendMenu.module.css'
 import Image from 'next/image'
-import { formatPrice } from '@/lib/format';
+import { Price } from '../price/Price';
 
 type recommendMenuProps = {
     recommendMenu: Menu;
@@ -27,7 +27,7 @@ export default function RecommendMenu ({ recommendMenu }: recommendMenuProps) {
             <div className={styles.itemInfo}>
                 <p className={styles.itemName}>{recommendMenu.name}</p>
                 <p className={styles.itemDesc}>{recommendMenu.detail}</p>
-                <p className={styles.itemPrice}>¥{formatPrice(recommendMenu.price)}</p>
+                <Price price={recommendMenu.price} />
             </div>
         </div>
     )

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -3,6 +3,7 @@ import { Sun, Moon, User, Baby, Banknote, Heart } from 'lucide-react';
 import styles from './SpotCard.module.css';
 import btnStyles from '@/styles/common-buttons.module.css';
 import Image from "next/image"
+import { formatPrice } from '@/lib/format';
 
 // 将来的にtypesディレクトリに移動
 type SpotKinds = "restaurant" | "sightseeing_spot" | "gift_spot" | "resting_spot" | string;
@@ -135,7 +136,7 @@ export const SpotCard = ({
                             >
                             {config.icon1}
                             </span>
-                            {price1 || "-"}
+                            {formatPrice(price1) || "-"}
                         </div>
                     )}
                 </div>
@@ -157,7 +158,7 @@ export const SpotCard = ({
                             >
                             {config.icon2}
                             </span>
-                            {price2 || "-"}
+                            {formatPrice(price2) || "-"}
                         </div>
                     )}
                 </div>

--- a/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
+++ b/miniApp/frontend/components/atoms/spotInfoTable/SpotInfoTable.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, ReactNode } from "react";
 import styles from "./SpotInfoTable.module.css";
+import { formatPrice } from "@/lib/format";
 
 export interface InfoItem {
   label: string;
@@ -67,7 +68,7 @@ export const BudgetRow: FunctionComponent<{
   iconBgColor: string;
   label: string | number | undefined | null;
 }> = ({ icon, iconBgColor, label }) => {
-  const displayLabel = (label ?? "") !== "" ? label : "情報なし";
+  const displayLabel = (label ?? "") !== "" ? formatPrice(label) : "情報なし";
   return (
     <div className={styles.budgetRow}>
       <span className={styles.budgetIcon} style={{ backgroundColor: iconBgColor }}>

--- a/miniApp/frontend/lib/format.ts
+++ b/miniApp/frontend/lib/format.ts
@@ -1,0 +1,20 @@
+/**
+ * 金額に3桁ごとのカンマを追加する
+ * 
+ * @param price 金額（数値または文字列）
+ * @returns カンマ区切り済みの文字列
+ */
+export const formatPrice = (price: string | number | undefined | null): string => {
+  if (price === undefined || price === null || String(price).trim() === "") return "";
+  
+  // 数値への変換を試みる
+  const num = Number(price);
+  
+  // 有効な数値であれば、ja-JPロケールを明示してフォーマット
+  if (!isNaN(num) && typeof num === 'number') {
+    return num.toLocaleString('ja-JP');
+  }
+  
+  // 数値として扱えない場合はそのまま返す
+  return String(price);
+};


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
メニューのスタイルを最適化しました
## 変更の理由・背景
- 

## 変更内容
- GeneralMenus と RecommendMenu のメニュー名に line-clamp を適用し、長い名称でも2行まで表示されるよう変更
- GeneralMenus の価格表示との間にあるドット線の垂直位置を微調整
- 価格表示用の共通コンポーネント Price を新規作成し、一貫したスタイルを適用
- GeneralMenus および RecommendMenu で直接記述していた価格表示を Price コンポーネントに置き換え
- 各コンポーネントの CSS から重複していた価格関連のスタイルを削除し、コードを整理
- 金額フォーマット用の共通関数 `formatPrice` を `lib/format.ts` に新規作成
- 各コンポーネント（GeneralMenus, RecommendMenu, SpotCard, SpotInfoTable）の金額・予算表示に適用し、可読性を向上

## スクリーンショット（UI変更がある場合）
<img width="375" height="329" alt="image" src="https://github.com/user-attachments/assets/ad54d73c-b99b-4847-8502-a3d5c41762db" />

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 