### PR TITLE
Fix: モバイル端末のセーフエリア対応とレイアウト定数の共通化

### DIFF
--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -30,6 +30,11 @@ h1, h2{
   --text-black: #1E1E1E;
   --text-gray: #999999;
 
+  /* Layout Constants */
+  --footer-action-bottom-padding: 34px; /* 必ず34pxに固定 */
+  --footer-action-height: 94px; /* 上パディング(12px) + ボタン高さ(48px) + 下パディング(34px) */
+  --safe-area-bottom: env(safe-area-inset-bottom);
+
   /* Font sizes */
   --title-size: 2rem;
   --subtitle-size: 1.2rem;

--- a/miniApp/frontend/app/layout.tsx
+++ b/miniApp/frontend/app/layout.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1.0,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/miniApp/frontend/app/page.module.css
+++ b/miniApp/frontend/app/page.module.css
@@ -9,7 +9,7 @@
 
 .menuBar {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom) + 5px);
+  bottom: calc(var(--safe-area-bottom) + 5px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;

--- a/miniApp/frontend/app/spots/restaurant/page.module.css
+++ b/miniApp/frontend/app/spots/restaurant/page.module.css
@@ -38,7 +38,7 @@
 .container {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--text-black);
-  padding-bottom: 80px; /* Space for fixed bottom buttons and nav */
+  padding-bottom: var(--footer-action-height); /* Space for fixed bottom buttons and nav */
   max-width: 500px;
   margin: 0 auto;
 }
@@ -230,7 +230,7 @@
   bottom: 0px; /* Above bottom nav */
   left: 0;
   right: 0;
-  padding: 12px 20px;
+  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
   display: flex;
   gap: 12px;
   align-items: center;

--- a/miniApp/frontend/app/spots/resting/page.module.css
+++ b/miniApp/frontend/app/spots/resting/page.module.css
@@ -38,7 +38,7 @@
 .container {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--text-black);
-  padding-bottom: 80px;
+  padding-bottom: var(--footer-action-height);
   max-width: 500px;
   margin: 0 auto;
 }
@@ -162,7 +162,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 20px;
+  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
   display: flex;
   gap: 12px;
   align-items: center;

--- a/miniApp/frontend/app/spots/shop/page.module.css
+++ b/miniApp/frontend/app/spots/shop/page.module.css
@@ -38,7 +38,7 @@
 .container {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--text-black);
-  padding-bottom: 80px;
+  padding-bottom: var(--footer-action-height);
   max-width: 500px;
   margin: 0 auto;
 }
@@ -168,7 +168,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 20px;
+  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
   display: flex;
   gap: 12px;
   align-items: center;

--- a/miniApp/frontend/app/spots/sightseeing/page.module.css
+++ b/miniApp/frontend/app/spots/sightseeing/page.module.css
@@ -38,7 +38,7 @@
 .container {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--text-black);
-  padding-bottom: 80px;
+  padding-bottom: var(--footer-action-height);
   max-width: 500px;
   margin: 0 auto;
 }
@@ -162,7 +162,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 20px;
+  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
   display: flex;
   gap: 12px;
   align-items: center;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -176,7 +176,7 @@
    フッター
 ================================= */
 .cardFooter {
-    padding: 0px 5% 10px 5%;
+    padding: 0px 5% 34px 5%;
     display: flex;
     gap: 12px;
     align-items: center;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -135,7 +135,7 @@
 }
 
 .cardFooter {
-    padding: 0px 5% 10px 5%;
+    padding: 0px 5% 34px 5%;
     display: flex;
     align-items: center;
     gap: 12px;

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -68,12 +68,14 @@
 
 /* カード表示領域（ピン選択時） */
 .cardWrapper {
-  position: absolute;
+  position: fixed; /* absoluteからfixedに変更して位置をより安定させる */
   left: 0;
-  bottom: 0px; /* 元々あったメニューバーの余白を詰め、下部にカードを下ろす */
+  bottom: 0;
   width: 100%;
   z-index: 10;
-  transition: all 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  /* 下部の余白はカード本体（SpotCard）のパディングで34px確保するため、ここでは0にする */
+  padding-bottom: 0;
 }
 
 /* カードのリスト（横スクロール用） */
@@ -81,7 +83,7 @@
   display: flex;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
-  padding: 20px 0; /* シャドウが上下に見切れないようにパディングを追加 */
+  padding: 20px 0 0 0;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
@@ -96,7 +98,7 @@
   scroll-snap-stop: always;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end; /* カードをコンテナの下部に揃える */
 }
 
 /* カード自体の横幅制御 */


### PR DESCRIPTION


<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
モバイル端末のセーフエリア対応とレイアウト定数の共通化
し、レイアウトを安定化

## 変更内容
- viewportFit: "cover" を設定し、ノッチ付きデバイス等の全画面表示に対応
- globals.css にセーフエリアおよびフッター高の共通変数を定義
- 各スポット詳細画面（レストラン、休憩所等）のフッターパディングを共通変数に移行
- スポットカードのボトムパディングを iOS のセーフエリア等に合わせて 34px に統一
- マップコンポーネントのカード表示位置を fixed に変更

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 