### PR TITLE
Refactor: スポット詳細ページのアクションフッターを共通コンポーネント化

### DIFF
--- a/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/restaurant/[id]/page.tsx
@@ -3,11 +3,8 @@ import { createClient } from '@/lib/supabase/client';
 import { notFound, useRouter } from 'next/navigation';
 import { useState, useEffect, use } from 'react';
 import styles from '../page.module.css'; 
-import btnStyles from '@/styles/common-buttons.module.css';
 import {
   Clock,
-  ExternalLink,
-  Heart,
   ChevronLeft,
   X,
   Sun,
@@ -19,12 +16,12 @@ import RecommendMenu from "@/components/atoms/recommendMenu/RecommendMenu";
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import GeneralMenus from "@/components/atoms/generalMenus/GeneralMenus"
 import Tags from "@/components/atoms/tags/Tags";
-import { useFavorites } from '@/hooks/useFavorites';
 import { SpotDetailSkeleton } from '@/components/atoms/spotCard/SpotDetailSkeleton';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink, BudgetRow } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToRestaurant, RawRestaurant } from "@/lib/spot-mapper";
+import SpotActionFooter from "@/components/atoms/spotActionFooter/SpotActionFooter";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -42,8 +39,6 @@ export default function RestaurantDetailPage({ params }: Props) {
   
   const [showNav, setShowNav] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
-
-  const { isFavorite, toggleFavorite } = useFavorites();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -271,49 +266,7 @@ export default function RestaurantDetailPage({ params }: Props) {
 
       <Disclaimer />
 
-      {/* Action Footer */}
-      <div className={styles.actionFooter}>
-        {spot.reservationURL ? (
-          <a 
-            href={spot.reservationURL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={btnStyles.reserveBtn}
-          >
-            予約する
-          </a>
-        ) : spot.phoneNumber ? (
-          <a 
-            href={`tel:${spot.phoneNumber}`}
-            className={btnStyles.reserveBtn}
-          >
-            電話する
-          </a>
-        ) : (
-          <button className={btnStyles.reserveBtn} disabled>
-            予約不可
-          </button>
-        )}
-        <a 
-          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={btnStyles.routeBtn}
-          style={{ flex: 1.5 }}
-        >
-          ルートを見る <ExternalLink size={18} />
-        </a>
-        <button 
-          className={btnStyles.heartBtn}
-          onClick={() => toggleFavorite(id)}
-        >
-          <Heart 
-            size={24} 
-            fill={isFavorite(id) ? "#EF5350" : "none"} 
-            color={isFavorite(id) ? "#EF5350" : "currentColor"}
-          />
-        </button>
-      </div>
+      <SpotActionFooter spot={spot} showReservation={true} />
     </div>
   );
 }

--- a/miniApp/frontend/app/spots/restaurant/page.module.css
+++ b/miniApp/frontend/app/spots/restaurant/page.module.css
@@ -224,17 +224,3 @@
   border-radius: 8px;
 }
 
-/* Footer UI */
-.actionFooter {
-  position: fixed;
-  bottom: 0px; /* Above bottom nav */
-  left: 0;
-  right: 0;
-  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  z-index: 100;
-  max-width: 500px;
-  margin: 0 auto;
-}

--- a/miniApp/frontend/app/spots/resting/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/resting/[id]/page.tsx
@@ -3,22 +3,19 @@ import { createClient } from '@/lib/supabase/client';
 import { notFound, useRouter } from 'next/navigation';
 import { useState, useEffect, use } from 'react';
 import styles from '../page.module.css'; 
-import btnStyles from '@/styles/common-buttons.module.css';
 import {
   Clock,
-  ExternalLink,
-  Heart,
   ChevronLeft,
   X,
 } from "lucide-react";
 
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
-import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToRestingSpot, formatFacilities, RawRestingSpot } from "@/lib/spot-mapper";
+import SpotActionFooter from "@/components/atoms/spotActionFooter/SpotActionFooter";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -35,8 +32,6 @@ export default function RestingDetailPage({ params }: Props) {
   
   const [showNav, setShowNav] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
-
-  const { isFavorite, toggleFavorite } = useFavorites();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -201,28 +196,7 @@ export default function RestingDetailPage({ params }: Props) {
 
       <Disclaimer />
 
-      {/* Action Footer */}
-      <div className={styles.actionFooter}>
-        <a 
-          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={btnStyles.routeBtn}
-          style={{ flex: 1.5 }}
-        >
-          ルートを見る <ExternalLink size={18} />
-        </a>
-        <button 
-          className={btnStyles.heartBtn}
-          onClick={() => toggleFavorite(id)}
-        >
-          <Heart 
-            size={24} 
-            fill={isFavorite(id) ? "#EF5350" : "none"} 
-            color={isFavorite(id) ? "#EF5350" : "currentColor"}
-          />
-        </button>
-      </div>
+      <SpotActionFooter spot={spot} />
     </div>
   );
 }

--- a/miniApp/frontend/app/spots/resting/page.module.css
+++ b/miniApp/frontend/app/spots/resting/page.module.css
@@ -157,16 +157,3 @@
   color: #666;
 }
 
-.actionFooter {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  z-index: 100;
-  max-width: 500px;
-  margin: 0 auto;
-}

--- a/miniApp/frontend/app/spots/shop/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/shop/[id]/page.tsx
@@ -3,11 +3,8 @@ import { createClient } from '@/lib/supabase/client';
 import { notFound, useRouter } from 'next/navigation';
 import { useState, useEffect, use } from 'react';
 import styles from '../page.module.css'; 
-import btnStyles from '@/styles/common-buttons.module.css';
 import {
   Clock,
-  ExternalLink,
-  Heart,
   ChevronLeft,
   X,
 } from "lucide-react";
@@ -16,11 +13,11 @@ import { Menu } from '@/types/menu'
 import RecommendMenu from "@/components/atoms/recommendMenu/RecommendMenu";
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
-import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToShop, RawShop } from "@/lib/spot-mapper";
+import SpotActionFooter from "@/components/atoms/spotActionFooter/SpotActionFooter";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -38,8 +35,6 @@ export default function ShopDetailPage({ params }: Props) {
   
   const [showNav, setShowNav] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
-
-  const { isFavorite, toggleFavorite } = useFavorites();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -227,28 +222,7 @@ export default function ShopDetailPage({ params }: Props) {
 
       <Disclaimer />
 
-      {/* Action Footer */}
-      <div className={styles.actionFooter}>
-        <a 
-          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={btnStyles.routeBtn}
-          style={{ flex: 1.5 }}
-        >
-          ルートを見る <ExternalLink size={18} />
-        </a>
-        <button 
-          className={btnStyles.heartBtn}
-          onClick={() => toggleFavorite(id)}
-        >
-          <Heart 
-            size={24} 
-            fill={isFavorite(id) ? "#EF5350" : "none"} 
-            color={isFavorite(id) ? "#EF5350" : "currentColor"}
-          />
-        </button>
-      </div>
+      <SpotActionFooter spot={spot} />
     </div>
   );
 }

--- a/miniApp/frontend/app/spots/shop/page.module.css
+++ b/miniApp/frontend/app/spots/shop/page.module.css
@@ -163,16 +163,3 @@
   cursor: pointer;
 }
 
-.actionFooter {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  z-index: 100;
-  max-width: 500px;
-  margin: 0 auto;
-}

--- a/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
+++ b/miniApp/frontend/app/spots/sightseeing/[id]/page.tsx
@@ -3,22 +3,19 @@ import { createClient } from '@/lib/supabase/client';
 import { notFound, useRouter } from 'next/navigation';
 import { useState, useEffect, use } from 'react';
 import styles from '../page.module.css'; 
-import btnStyles from '@/styles/common-buttons.module.css';
 import {
   Clock,
-  ExternalLink,
-  Heart,
   ChevronLeft,
   X,
 } from "lucide-react";
 
 import PhotoGallery from "@/components/atoms/photoGallery/PhotoGallery";
 import Tags from "@/components/atoms/tags/Tags";
-import { useFavorites } from '@/hooks/useFavorites';
 import NearbySpots from "@/components/organisms/nearbySpots/NearbySpots";
 import { SpotInfoTable, InfoLink } from "@/components/atoms/spotInfoTable/SpotInfoTable";
 import { Disclaimer } from "@/components/atoms/disclaimer/Disclaimer";
 import { mapToSightseeingSpot, RawSightseeingSpot } from "@/lib/spot-mapper";
+import SpotActionFooter from "@/components/atoms/spotActionFooter/SpotActionFooter";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -35,9 +32,6 @@ export default function SightseeingDetailPage({ params }: Props) {
 
   const [showNav, setShowNav] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
-
-  const { isFavorite, toggleFavorite } = useFavorites();
-
 
   useEffect(() => {
     const fetchData = async () => {
@@ -200,28 +194,7 @@ export default function SightseeingDetailPage({ params }: Props) {
 
       <Disclaimer />
 
-      {/* Action Footer */}
-      <div className={styles.actionFooter}>
-        <a 
-          href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={btnStyles.routeBtn}
-          style={{ flex: 1.5 }}
-        >
-          ルートを見る <ExternalLink size={18} />
-        </a>
-        <button 
-          className={btnStyles.heartBtn}
-          onClick={() => toggleFavorite(id)}
-        >
-          <Heart 
-            size={24} 
-            fill={isFavorite(id) ? "#EF5350" : "none"} 
-            color={isFavorite(id) ? "#EF5350" : "currentColor"}
-          />
-        </button>
-      </div>
+      <SpotActionFooter spot={spot} />
     </div>
   );
 }

--- a/miniApp/frontend/app/spots/sightseeing/page.module.css
+++ b/miniApp/frontend/app/spots/sightseeing/page.module.css
@@ -157,16 +157,3 @@
   color: #666;
 }
 
-.actionFooter {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  z-index: 100;
-  max-width: 500px;
-  margin: 0 auto;
-}

--- a/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.module.css
+++ b/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.module.css
@@ -1,0 +1,15 @@
+.actionFooter {
+  position: fixed;
+  bottom: 0px; /* Above bottom nav */
+  left: 0;
+  right: 0;
+  padding: 12px 20px var(--footer-action-bottom-padding) 20px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  z-index: 100;
+  max-width: 500px;
+  margin: 0 auto;
+  background-color: white; /* Added to ensure it covers content below */
+  box-shadow: 0px 5px 15px 0px rgba(0, 0, 0, 0.35);
+}

--- a/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.tsx
+++ b/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from 'react';
+import { ExternalLink, Heart } from 'lucide-react';
+import { Spot } from '@/types/spot';
+import { useFavorites } from '@/hooks/useFavorites';
+import styles from './SpotActionFooter.module.css';
+import btnStyles from '@/styles/common-buttons.module.css';
+
+interface SpotActionFooterProps {
+  spot: Spot;
+  showReservation?: boolean;
+}
+
+const SpotActionFooter: React.FC<SpotActionFooterProps> = ({ 
+  spot, 
+  showReservation = false 
+}) => {
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const id = spot.id;
+
+  return (
+    <div className={styles.actionFooter}>
+      {showReservation && (
+        <>
+          {spot.reservationURL ? (
+            <a 
+              href={spot.reservationURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={btnStyles.reserveBtn}
+            >
+              予約する
+            </a>
+          ) : spot.phoneNumber ? (
+            <a 
+              href={`tel:${spot.phoneNumber}`}
+              className={btnStyles.reserveBtn}
+            >
+              電話する
+            </a>
+          ) : (
+            <button className={btnStyles.reserveBtn} disabled>
+              予約不可
+            </button>
+          )}
+        </>
+      )}
+      
+      <a 
+        href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${spot.name} ${spot.address}`)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={btnStyles.routeBtn}
+        style={{ flex: showReservation ? 1.5 : 1 }}
+      >
+        ルートを見る <ExternalLink size={18} />
+      </a>
+      
+      <button 
+        className={btnStyles.heartBtn}
+        onClick={() => toggleFavorite(id)}
+      >
+        <Heart 
+          size={24} 
+          fill={isFavorite(id) ? "#EF5350" : "none"} 
+          color={isFavorite(id) ? "#EF5350" : "currentColor"}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default SpotActionFooter;


### PR DESCRIPTION


<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポット詳細ページのアクションフッターを共通コンポーネント化
## 変更内容
- 新しい `SpotActionFooter` コンポーネントを作成し、フッターのロジック（予約・電話、ルート検索、お気に入り）を共通化
- 飲食店、休憩所、ショップ、観光地の各詳細ページから重複していた実装を削除し、新コンポーネントへ移行
- 各ページのスタイルシートから不要になったフッター用の定義を削除

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 