### PR TITLE
Feat: お気に入りボタンコンポーネントの追加とブックマークアイコンへの統一

### DIFF
--- a/miniApp/frontend/components/atoms/favoriteButton/FavoriteButton.module.css
+++ b/miniApp/frontend/components/atoms/favoriteButton/FavoriteButton.module.css
@@ -1,0 +1,101 @@
+:where(.favoriteButton) {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+  background: none;
+  border: none;
+}
+
+.favoriteButton {
+  /* Only keep non-conflicting layout styles if needed, 
+     but :where covers the ones we want to be overridable */
+}
+
+.favoriteWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.burstContainer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 48px;
+  height: 48px;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background-color: var(--primary-color);
+  border-radius: 50%;
+  opacity: 0;
+}
+
+.animate .particle {
+  animation: burst-animation 0.6s cubic-bezier(0.1, 0.8, 0.3, 1) forwards;
+}
+
+/* 8 directions for the "fireworks" - increased distance */
+.particle:nth-child(1) { --dx: 0px; --dy: -40px; }
+.particle:nth-child(2) { --dx: 28px; --dy: -28px; }
+.particle:nth-child(3) { --dx: 40px; --dy: 0px; }
+.particle:nth-child(4) { --dx: 28px; --dy: 28px; }
+.particle:nth-child(5) { --dx: 0px; --dy: 40px; }
+.particle:nth-child(6) { --dx: -28px; --dy: 28px; }
+.particle:nth-child(7) { --dx: -40px; --dy: 0px; }
+.particle:nth-child(8) { --dx: -28px; --dy: -28px; }
+
+@keyframes burst-animation {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(1);
+    opacity: 0;
+  }
+}
+
+/* Scale effect for the icon itself */
+.iconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.animate .iconWrapper {
+  animation: pop-animation 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.iconActive {
+  fill: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.iconInactive {
+  fill: none;
+  color: currentColor;
+}
+
+@keyframes pop-animation {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.4); }
+  100% { transform: scale(1); }
+}

--- a/miniApp/frontend/components/atoms/favoriteButton/FavoriteButton.tsx
+++ b/miniApp/frontend/components/atoms/favoriteButton/FavoriteButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { Bookmark } from 'lucide-react';
+import styles from './FavoriteButton.module.css';
+
+interface FavoriteButtonProps {
+  isFavorite: boolean;
+  onClick: () => void;
+  size?: number;
+  className?: string;
+}
+
+const FavoriteButton: React.FC<FavoriteButtonProps> = ({ 
+  isFavorite, 
+  onClick, 
+  size = 24,
+  className = ""
+}) => {
+  const [isAnimate, setIsAnimate] = useState(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (isAnimate) {
+      timer = setTimeout(() => setIsAnimate(false), 600);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [isAnimate]);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // お気に入りに追加されるとき（現在は未登録のとき）にアニメーションを実行
+    if (!isFavorite) {
+      setIsAnimate(true);
+    }
+    onClick();
+  };
+
+  return (
+    <button 
+      className={`${styles.favoriteButton} ${isAnimate ? styles.animate : ''} ${className}`}
+      onClick={handleClick}
+      aria-label={isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
+    >
+      <div className={styles.favoriteWrapper}>
+        <div className={styles.burstContainer}>
+          {[...Array(8)].map((_, i) => (
+            <div key={i} className={styles.particle} />
+          ))}
+        </div>
+        <div className={styles.iconWrapper}>
+          <Bookmark 
+            size={size} 
+            className={isFavorite ? styles.iconActive : styles.iconInactive}
+          />
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default FavoriteButton;
+

--- a/miniApp/frontend/components/atoms/menuBar/MenuBar.tsx
+++ b/miniApp/frontend/components/atoms/menuBar/MenuBar.tsx
@@ -11,7 +11,7 @@ import {
 import{
     Map,
     Route,
-    Heart,
+    Bookmark,
     User,
     Search
 } from "lucide-react";
@@ -27,7 +27,7 @@ export default function MenuBar(){
     const getValueFromPath = (path: string) => {
         if (path.startsWith('/maps')) return 'map';
         if (path.startsWith('/modelcourse')) return 'route';
-        if (path.startsWith('/favorites')) return 'heart';
+        if (path.startsWith('/favorites')) return 'bookmark';
         if (path.startsWith('/mypage')) return 'user';
         if (path.startsWith('/search')) return 'search';
         return 'map';
@@ -92,9 +92,9 @@ export default function MenuBar(){
                         sx={{ ...labelPreventWrapStyle, ...selectedStyle }} 
                     />
                     <BottomNavigationAction 
-                        value="heart" 
+                        value="bookmark" 
                         label="保存" 
-                        icon={<Heart/>} 
+                        icon={<Bookmark/>} 
                         component={Link}
                         href="/favorites"
                         sx={{ ...labelPreventWrapStyle, ...selectedStyle }} 

--- a/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.tsx
+++ b/miniApp/frontend/components/atoms/spotActionFooter/SpotActionFooter.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React from 'react';
-import { ExternalLink, Heart } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { Spot } from '@/types/spot';
 import { useFavorites } from '@/hooks/useFavorites';
+import FavoriteButton from '@/components/atoms/favoriteButton/FavoriteButton';
 import styles from './SpotActionFooter.module.css';
 import btnStyles from '@/styles/common-buttons.module.css';
 
@@ -57,16 +58,11 @@ const SpotActionFooter: React.FC<SpotActionFooterProps> = ({
         ルートを見る <ExternalLink size={18} />
       </a>
       
-      <button 
-        className={btnStyles.heartBtn}
-        onClick={() => toggleFavorite(id)}
-      >
-        <Heart 
-          size={24} 
-          fill={isFavorite(id) ? "#EF5350" : "none"} 
-          color={isFavorite(id) ? "#EF5350" : "currentColor"}
-        />
-      </button>
+      <FavoriteButton 
+        isFavorite={isFavorite(id)} 
+        onClick={() => toggleFavorite(id)} 
+        className={btnStyles.favoriteBtn}
+      />
     </div>
   );
 };

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -189,7 +189,7 @@
 }
 
 .routeBtn,
-.heartBtn {
+.favoriteBtn {
     background-color: #f4f4f4 !important;
 }
 

--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from 'react';
-import { Sun, Moon, User, Baby, Banknote, Heart } from 'lucide-react';
+import { Sun, Moon, User, Baby, Banknote } from 'lucide-react';
 import styles from './SpotCard.module.css';
 import btnStyles from '@/styles/common-buttons.module.css';
 import Image from "next/image"
 import { formatPrice } from '@/lib/format';
+import FavoriteButton from '@/components/atoms/favoriteButton/FavoriteButton';
 
 // 将来的にtypesディレクトリに移動
 type SpotKinds = "restaurant" | "sightseeing_spot" | "gift_spot" | "resting_spot" | string;
@@ -176,16 +177,11 @@ export const SpotCard = ({
                 >
                     ルートを見る
                 </a>
-                <button 
-                    className={`${btnStyles.heartBtn} ${styles.heartBtn}`}
-                    onClick={onFavoriteToggle}
-                >
-                    <Heart 
-                        size={24} 
-                        fill={isFavorite ? "#EF5350" : "none"} 
-                        color={isFavorite ? "#EF5350" : "currentColor"} 
-                    />
-                </button>
+                <FavoriteButton 
+                    isFavorite={!!isFavorite} 
+                    onClick={onFavoriteToggle || (() => {})} 
+                    className={`${btnStyles.favoriteBtn} ${styles.favoriteBtn}`}
+                />
             </div>
         </div>
     );

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -156,9 +156,9 @@
     border-radius: 9999px;
 }
 
-.heartSkeleton {
-    flex: 0 0 clamp(34px, 8.5cqw, 44px);
-    width: clamp(34px, 8.5cqw, 44px);
+.favoriteSkeleton {
     height: clamp(34px, 8.5cqw, 44px);
+    width: clamp(34px, 8.5cqw, 44px);
+    flex: 0 0 clamp(34px, 8.5cqw, 44px);
     border-radius: 50%;
 }

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.tsx
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.tsx
@@ -38,7 +38,7 @@ export const SpotCardSkeleton = () => {
             <div className={styles.cardFooter}>
                 <div className={`${styles.skeleton} ${styles.buttonSkeleton}`} />
                 <div className={`${styles.skeleton} ${styles.buttonSkeleton}`} />
-                <div className={`${styles.skeleton} ${styles.heartSkeleton}`} />
+                <div className={`${styles.skeleton} ${styles.favoriteSkeleton}`} />
             </div>
         </div>
     );

--- a/miniApp/frontend/components/organisms/menuDrawer/MenuDrawer.tsx
+++ b/miniApp/frontend/components/organisms/menuDrawer/MenuDrawer.tsx
@@ -14,7 +14,7 @@ import {
   IconButton,
 } from "@mui/material";
 import {
-  Heart,
+  Bookmark,
   Bell,
   HelpCircle,
   MessageCircle,
@@ -28,7 +28,7 @@ type Props = {
 
 export const MenuDrawer = ({ open, onClose }: Props) => {
   const menuItems = [
-    { text: "保存済み", icon: <Heart size={20} />, href: "/favorites" },
+    { text: "保存済み", icon: <Bookmark size={20} />, href: "/favorites" },
     { text: "お知らせ", icon: <Bell size={20} />, href: "/news" },
   ];
 

--- a/miniApp/frontend/styles/common-buttons.module.css
+++ b/miniApp/frontend/styles/common-buttons.module.css
@@ -35,7 +35,7 @@
   border: 1.5px solid var(--primary-color);
 }
 
-.heartBtn {
+.favoriteBtn {
   composes: actionBtnBase;
   flex: 0 0 48px; /* Fixed size, not growing like other buttons */
   width: 48px;


### PR DESCRIPTION

<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
お気に入りボタンコンポーネントの追加とブックマークアイコンへの統一
## 変更内容
- アニメーション効果（バースト・ポップ）を持つ `FavoriteButton` コンポーネントを新規実装
- お気に入りアイコンを `Heart` から `Bookmark` に変更し、アプリ全体でデザインを統一
- `SpotCard` および `SpotActionFooter` で独自のボタン実装を `FavoriteButton` コンポーネントに置き換え
- スタイル名やスケルトン表示の名称を `heart` から `favorite` にリネームして整合性を確保

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 