### PR TITLE
fix: PhotoGalleryの画像表示をアスペクト比維持に変更

### DIFF
--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -20,15 +20,19 @@
 .imageContainer {
   position: relative;
   min-width: 100%;
+  width: 100%;
   flex-shrink: 0;
   height: 100%;
-  background-color: #1e1e1e; /* 背景を濃いグレーに変更 */
+  background-color: #000000; /* 背景を真っ黒にして余白を目立たなくする */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mainImage {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: contain !important; /* contain に変更してアスペクト比を維持 */
 }
 
 .mainVideo {

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -23,7 +23,7 @@
   width: 100%;
   flex-shrink: 0;
   height: 100%;
-  background-color: #000000; /* 背景を真っ黒にして余白を目立たなくする */
+  background-color: #1e1e1e; /* 元の濃いグレーに戻す */
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
PhotoGalleryの画像表示をアスペクト比維持に変更



## 変更内容
- object-fit を cover から contain に変更し、画像全体が切れることなく表示されるように修正
- 画像を中央に配置するための flexbox 設定を追加
- アスペクト比の違いによる余白を目立たなく調整

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 