### PR TITLE
Style: スポットカードの下部余白調整とレイアウト管理の最適化

### DIFF
--- a/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCard.module.css
@@ -177,7 +177,7 @@
    フッター
 ================================= */
 .cardFooter {
-    padding: 0px 5% 34px 5%;
+    padding: 0px 5% 12px 5%; /* 34pxから12pxに縮小 */
     display: flex;
     gap: 12px;
     align-items: center;

--- a/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
+++ b/miniApp/frontend/components/atoms/spotCard/SpotCardSkeleton.module.css
@@ -144,7 +144,7 @@
 }
 
 .cardFooter {
-    padding: 0px 5% 34px 5%;
+    padding: 0px 5% 12px 5%; /* 34pxから12pxに縮小 */
     display: flex;
     align-items: center;
     gap: 12px;

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -74,8 +74,8 @@
   width: 100%;
   z-index: 10;
   transition: transform 0.3s ease, opacity 0.3s ease;
-  /* 下部の余白はカード本体（SpotCard）のパディングで34px確保するため、ここでは0にする */
-  padding-bottom: 0;
+  /* カードと画面下部の間に余白(34px)を確保 */
+  padding-bottom: var(--footer-action-bottom-padding);
 }
 
 /* カードのリスト（横スクロール用） */
@@ -150,6 +150,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    padding-bottom: 0; /* 縦画面用の余白をリセット */
   }
 
   .cardListContainer {


### PR DESCRIPTION

<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
スポットカードの下部余白調整とレイアウト管理の最適化
## 変更内容
- SpotCard および SpotCardSkeleton のフッター下部パディングを 34px から 12px に縮小
- MapComponent のカードコンテナに画面下部との余白（var(--footer-action-bottom-padding)）を追加
- 余白の管理をコンポーネント単体から親コンテナ側へ移動し、レイアウトの柔軟性を向上
 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 