### PR TITLE
add:ノッチなどでカードやメニュードロワーが隠れてしまうため、paddingを追加しました

### DIFF
--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -33,7 +33,10 @@ h1, h2{
   /* Layout Constants */
   --footer-action-bottom-padding: 34px; /* 必ず34pxに固定 */
   --footer-action-height: 94px; /* 上パディング(12px) + ボタン高さ(48px) + 下パディング(34px) */
+  --safe-area-top: env(safe-area-inset-top);
   --safe-area-bottom: env(safe-area-inset-bottom);
+  --safe-area-left: env(safe-area-inset-left);
+  --safe-area-right: env(safe-area-inset-right);
 
   /* Font sizes */
   --title-size: 2rem;

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -136,16 +136,18 @@
 /* ----------- Landscape (横画面) 用のスタイル ----------- */
 @media (orientation: landscape) {
   .topBar {
-    left: 75%;
-    width: 48%;
+    left: auto;
+    right: 44px;
+    width: calc(50% - 44px);
+    transform: none;
   }
 
   /* カードコンテナを左半分に */
   .cardWrapper {
-    width: 50%;
-    height: 100%;
-    bottom: 0;
-    left: 0;
+    width: calc(50% - 44px);
+    height: calc(100% - 21px);
+    bottom: 21px;
+    left: 44px;
     top: 0;
     display: flex;
     flex-direction: column;
@@ -169,7 +171,7 @@
     margin: 20px 0;
     scroll-snap-align: center;
     justify-content: flex-start; /* 左寄せ */
-    padding-left: calc(20px + var(--safe-area-left, 0px)); /* 左側の隙間を10pxから20pxに倍増 + セーフエリア考慮 */
+    padding-left: 0; /* 固定で44px開けるためリセット */
   }
 
   .cardItem > div {
@@ -187,8 +189,8 @@
   /* 横画面用のスクロールインジケーター */
   .verticalIndicator {
     position: absolute;
-    /* カード(38vw) + 左の隙間(20px) のすぐ右側に配置 */
-    left: calc(38vw + 35px);
+    /* カード(38vw) のすぐ右側に配置 */
+    left: calc(38vw + 15px);
     right: auto;
     top: 50%;
     transform: translateY(-50%);

--- a/miniApp/frontend/components/organisms/map/MapComponent.module.css
+++ b/miniApp/frontend/components/organisms/map/MapComponent.module.css
@@ -169,7 +169,7 @@
     margin: 20px 0;
     scroll-snap-align: center;
     justify-content: flex-start; /* 左寄せ */
-    padding-left: 20px; /* 左側の隙間を10pxから20pxに倍増 */
+    padding-left: calc(20px + var(--safe-area-left, 0px)); /* 左側の隙間を10pxから20pxに倍増 + セーフエリア考慮 */
   }
 
   .cardItem > div {

--- a/miniApp/frontend/components/organisms/menuDrawer/MenuDrawer.tsx
+++ b/miniApp/frontend/components/organisms/menuDrawer/MenuDrawer.tsx
@@ -47,6 +47,7 @@ export const MenuDrawer = ({ open, onClose }: Props) => {
           width: 280,
           borderRadius: "20px 0 0 20px",
           padding: "16px 8px",
+          paddingRight: "calc(8px + var(--safe-area-right, 0px))",
           display: "flex",
           flexDirection: "column",
         },


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
横画面時に機種のノッチなどに合わせて、カードやメニュードロワーのpaddingを追加しました。

## 変更の理由・背景
- 機種によってカードやメニュードロワーが隠れてしまっていたから。

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 