### PR TITLE
fix:タグ検索の余白部分を押しても消えないようにしました。

### DIFF
--- a/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
+++ b/miniApp/frontend/components/atoms/searchTextField/SearchTextField.tsx
@@ -58,6 +58,7 @@ export const SearchTextField = ({ onSearch, onFocus, onBlur, label = "検索" }:
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
+        onClick={handleFocus}
         onBlur={handleBlur}
         className={styles.searchField}
         // ラベルが入力文字と重ならないよう、また浮き上がらないように制御

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -79,6 +79,38 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
   const [isSearchFocused, setIsSearchFocused] = useState(false); // 検索バーのフォーカス状態
   const [isLandscape, setIsLandscape] = useState(false); // 横画面状態
 
+  // タグ検索の履歴管理（戻るボタン対応）
+  const handleSearchFocus = () => {
+    if (!isSearchFocused) {
+      window.history.pushState({ searchOpen: true }, '');
+      setIsSearchFocused(true);
+    }
+  };
+
+  const handleSearchClose = () => {
+    if (isSearchFocused) {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+      if (window.history.state?.searchOpen) {
+        window.history.back();
+      } else {
+        setIsSearchFocused(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setIsSearchFocused(false);
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
   // クラスター用state
   const [zoom, setZoom] = useState(14);
   const [bounds, setBounds] = useState<[number, number, number, number] | null>(null);
@@ -454,14 +486,13 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       <div className={styles.topBar}>
         <SearchTextField 
           onSearch={(val) => setActiveKeyword(val)} 
-          onFocus={() => setIsSearchFocused(true)}
-          onBlur={() => setTimeout(() => setIsSearchFocused(false), 200)}
+          onFocus={handleSearchFocus}
           label="行きたい場所を検索" 
         />
         <MenuButton 
           onClick={() => {
             if (isSearchFocused) {
-              setIsSearchFocused(false);
+              handleSearchClose();
             } else {
               setIsMenuOpen(true);
             }


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
タグ検索の余白部分を押しても閉じないように修正しました。
スマホ・ミニアプリ固有の戻るボタンでタグ検索を閉じるように修正しました。

## 変更の理由・背景
- 横画面でキーパッドを閉じるため余白部分を押すと、タグ検索画面まで閉じてしまっていたため。

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [ x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 