### PR TITLE
add:スポットピンを選択時に、近隣の同一place_typeのスポットを3件のカードを横に表示する機能を追加しました

### DIFF
--- a/miniApp/frontend/app/api/search/route.ts
+++ b/miniApp/frontend/app/api/search/route.ts
@@ -12,8 +12,10 @@ export async function GET(request: Request) {
         const { searchParams } = new URL(request.url);
         const options = searchParams.get('options');
         const keyword = searchParams.get('keyword');
+        const placeType = searchParams.get('type');
         const lat = searchParams.get('lat');
         const lng = searchParams.get('lng');
+        const limit = parseInt(searchParams.get('limit') || '5', 10);
 
         // 距離計算用関数 (Haversine formula)
         const getDistance = (lat1: number, lng1: number, lat2: number, lng2: number) => {
@@ -29,7 +31,7 @@ export async function GET(request: Request) {
         };
 
         // バリデーション
-        if (!options && !keyword) {
+        if (!options && !keyword && !placeType) {
             return NextResponse.json([], { status: 200 });
         }
 
@@ -125,6 +127,36 @@ export async function GET(request: Request) {
                 throw error;
             }
             rawData = (data.spot_tags as unknown as { spots: RawSpot }[]).map((item) => item.spots).filter(Boolean);
+        } else if (placeType) {
+            // place_type による検索
+            const { data, error } = await supabase
+                .from('spots')
+                .select(`
+                    id,
+                    name,
+                    place_type,
+                    pricing,
+                    latitude,
+                    longitude,
+                    updated_at,
+                    spot_tags (
+                        tags (
+                            detail 
+                        )
+                    ),
+                    assets (
+                        url,
+                        is_cardthumbnail
+                    ),
+                    restaurants (
+                        avg_lunch_budget,
+                        avg_dinner_budget
+                    )
+                `)
+                .eq('place_type', placeType);
+
+            if (error) throw error;
+            rawData = (data as unknown as RawSpot[]) || [];
         }
 
         // フォーマットとソート
@@ -171,7 +203,7 @@ export async function GET(request: Request) {
             };
         });
 
-        // 現在地が渡されている場合は距離でソートし、5件に絞る
+        // 現在地が渡されている場合は距離でソートし、指定件数に絞る
         if (lat && lng) {
             const userLat = parseFloat(lat);
             const userLng = parseFloat(lng);
@@ -180,7 +212,7 @@ export async function GET(request: Request) {
                 const distB = getDistance(userLat, userLng, b.position.lat, b.position.lng);
                 return distA - distB;
             });
-            formattedData = formattedData.slice(0, 5);
+            formattedData = formattedData.slice(0, limit);
         }
 
         // 各スポットの営業状況を Google Places API (New) から取得 (上位のみ)
@@ -190,8 +222,8 @@ export async function GET(request: Request) {
 
         if (apiKey && formattedData.length > 0) {
             // 通信量とクォータを考慮し、既に絞り込まれた上位数件のみ取得
-            // 距離ソートされていない場合（現在地なし）でも、念のため最初の5件に制限
-            const targetData = formattedData.slice(0, 5);
+            // 距離ソートされていない場合（現在地なし）でも、指定件数に制限
+            const targetData = formattedData.slice(0, limit);
             
             const resultsWithOpenStatus = await Promise.all(targetData.map(async (spot) => {
                 let isOpen: boolean | null = null;

--- a/miniApp/frontend/components/organisms/map/MapComponent.tsx
+++ b/miniApp/frontend/components/organisms/map/MapComponent.tsx
@@ -432,12 +432,13 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
       return;
     }
     
-    // リストにない場合、新規スポット1件のみを表示する形に切り替える（リストが際限なく増えるのを防ぐ）
+    // リストにない場合、周辺の同一種別のスポットを含めて表示する
     const inferredSpotKind = PIN_METADATA[pinKind]?.spotKind || "spot";
 
     setIsCardLoading(true);
     lastRequestSpotId.current = spotId;
 
+    // とりあえずクリックされたスポットをプレースホルダーとして表示
     const dummySpot: MapSpotData = {
       id: spotId,
       position: position,
@@ -455,16 +456,34 @@ export const MapComponent = ({ initialSpots, keyword, options: searchOptions }: 
     setSelectedSpot(dummySpot);
 
     try {
+      // 1. まずクリックされたスポットの正確な情報を取得して、その種類(place_type)を確認
       const response = await fetch(`/api/spotcard?id=${spotId}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch spot details: ${response.status}`);
       }
-      const detailData: MapSpotData = await response.json();
+      const clickedSpot: MapSpotData = await response.json();
+
+      // 2. そのスポットの種類と同じ、周辺のスポットを取得する（クリックしたスポットが必ず含まれることを考慮して4件要求）
+      const nearbyResponse = await fetch(
+        `/api/search?type=${clickedSpot.spotKind}&lat=${position.lat}&lng=${position.lng}&limit=4`
+      );
+      
+      let finalCards = [clickedSpot];
+
+      if (nearbyResponse.ok) {
+        const nearbySpots: MapSpotData[] = await nearbyResponse.json();
+        if (nearbySpots.length > 0) {
+          // クリックしたスポットが検索結果に含まれているか確認し、重複を除去してマージ
+          const otherSpots = nearbySpots.filter(s => s.id !== clickedSpot.id);
+          // 選択したスポット + 他のスポット最大3件（合計4件）にする
+          finalCards = [clickedSpot, ...otherSpots.slice(0, 3)];
+        }
+      }
       
       // レースコンディション対策：最新のリクエストのみ処理
       if (lastRequestSpotId.current === spotId) {
-        setDisplayCards([detailData]);
-        setSelectedSpot(detailData);
+        setDisplayCards(finalCards);
+        setSelectedSpot(clickedSpot);
       }
     } catch (e) { 
       console.error("スポット詳細取得失敗:", e);


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
検索と同様に、ピンを選択すると同一place_typeの近隣スポットを最大3件カードで表示する。

## 変更の理由・背景
- 

## 変更内容
- 
- 

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x ] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 