### PR TITLE
feat: PhotoGalleryを指に追従するようにしました。

### DIFF
--- a/miniApp/frontend/app/globals.css
+++ b/miniApp/frontend/app/globals.css
@@ -4,6 +4,8 @@ body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
   color: var(--text-black);
+  overflow-x: hidden; /* ページ全体の横揺れを防ぐ */
+  width: 100%;
 }
 
 a {

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.module.css
@@ -10,6 +10,8 @@
     width: 100%;
     height: 100%;      /* ここで具体的な高さを指定 */
     overflow: hidden;
+    touch-action: pan-y; /* 垂直スクロールは許可し、水平方向はJSで制御する */
+    overscroll-behavior-x: none; /* ブラウザの戻る・進むジェスチャーを防止 */
 }
 .imageTrack {
   display: flex;

--- a/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
+++ b/miniApp/frontend/components/atoms/photoGallery/PhotoGallery.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import styles from "./PhotoGallery.module.css";
 import Image from "next/image";
 import {
@@ -13,6 +13,10 @@ interface PhotoGalleryProps {
 
 export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
     const headerImages = images || [];
+    const containerRef = useRef<HTMLDivElement>(null);
+    const trackRef = useRef<HTMLDivElement>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
+
     // クローンを追加した画像リストを作成
     const extendedImages = headerImages.length > 1 
         ? [headerImages[headerImages.length - 1], ...headerImages, headerImages[0]]
@@ -20,11 +24,37 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
 
     const [currentImgIndex, setCurrentImgIndex] = useState(headerImages.length > 1 ? 1 : 0);
     const [isTransitioning, setIsTransitioning] = useState(false);
-    const [touchStart, setTouchStart] = useState<number | null>(null);
-    const [touchEnd, setTouchEnd] = useState<number | null>(null);
+    
+    // ドラッグ管理用のRef (レンダリングをトリガーしない)
+    const dragInfo = useRef({
+        isDragging: false,
+        touchStart: 0,
+        dragOffset: 0,
+        rafId: 0
+    });
 
-    // スワイプの最小距離（px）
-    const minSwipeDistance = 50;
+    useEffect(() => {
+        const updateWidth = () => {
+            if (containerRef.current) {
+                setContainerWidth(containerRef.current.offsetWidth);
+            }
+        };
+        updateWidth();
+        window.addEventListener("resize", updateWidth);
+        return () => window.removeEventListener("resize", updateWidth);
+    }, []);
+
+    // インデックスや幅、アニメーション状態が変わったときに位置を更新する
+    useEffect(() => {
+        if (trackRef.current && containerWidth > 0) {
+            // ドラッグ中でないときのみ位置を同期する
+            if (!dragInfo.current.isDragging) {
+                // アニメーション中ならtransitionを設定、そうでなければ即時反映（ワープ用）
+                trackRef.current.style.transition = isTransitioning ? 'transform 0.3s ease-out' : 'none';
+                trackRef.current.style.transform = `translateX(-${currentImgIndex * 100}%)`;
+            }
+        }
+    }, [currentImgIndex, containerWidth, isTransitioning]);
 
     const nextImage = useCallback(() => {
         if (headerImages.length <= 1 || isTransitioning) return;
@@ -44,15 +74,65 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
 
         // クローンに到達した瞬間に、アニメーションなしで本物の位置へワープする
         if (currentImgIndex === 0) {
-            // 先頭のクローン（最後の画像）にいる場合 -> 本物の最後へ
             setCurrentImgIndex(headerImages.length);
         } else if (currentImgIndex === headerImages.length + 1) {
-            // 末尾のクローン（最初の画像）にいる場合 -> 本物の最初へ
             setCurrentImgIndex(1);
         }
     };
 
-    // インジケーター用の現在のアクティブなインデックス
+    const onTouchStart = (e: React.TouchEvent) => {
+        if (isTransitioning || headerImages.length <= 1) return;
+        e.stopPropagation();
+        dragInfo.current.isDragging = true;
+        dragInfo.current.touchStart = e.targetTouches[0].clientX;
+        dragInfo.current.dragOffset = 0;
+        
+        if (trackRef.current) {
+            trackRef.current.style.transition = 'none';
+        }
+    };
+
+    const onTouchMove = (e: React.TouchEvent) => {
+        if (!dragInfo.current.isDragging) return;
+        e.stopPropagation();
+        
+        const currentX = e.targetTouches[0].clientX;
+        dragInfo.current.dragOffset = currentX - dragInfo.current.touchStart;
+
+        // requestAnimationFrameで描画を最適化
+        cancelAnimationFrame(dragInfo.current.rafId);
+        dragInfo.current.rafId = requestAnimationFrame(() => {
+            if (trackRef.current && containerWidth > 0) {
+                const baseTranslate = -currentImgIndex * 100;
+                const dragTranslate = (dragInfo.current.dragOffset / containerWidth) * 100;
+                trackRef.current.style.transform = `translateX(${baseTranslate + dragTranslate}%)`;
+            }
+        });
+    };
+
+    const onTouchEnd = (e: React.TouchEvent) => {
+        if (!dragInfo.current.isDragging) return;
+        e.stopPropagation();
+        
+        dragInfo.current.isDragging = false;
+        cancelAnimationFrame(dragInfo.current.rafId);
+
+        const threshold = containerWidth * 0.2;
+        const offset = dragInfo.current.dragOffset;
+
+        if (offset < -threshold) {
+            nextImage();
+        } else if (offset > threshold) {
+            prevImage();
+        } else {
+            // スナップバック (indexは変わらないがアニメーションをトリガーする)
+            setIsTransitioning(true);
+            // indexが変わらない場合でもuseEffectを走らせるために、
+            // もし既にfalseなら一度trueにすることで再描画を促す
+        }
+    };
+
+    // インジケーター用
     const activeDotIndex = headerImages.length > 1 
         ? (currentImgIndex === 0 
             ? headerImages.length - 1 
@@ -61,39 +141,14 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
                 : currentImgIndex - 1)
         : 0;
 
-    const onTouchStart = (e: React.TouchEvent) => {
-        setTouchEnd(null);
-        setTouchStart(e.targetTouches[0].clientX);
-    };
-
-    const onTouchMove = (e: React.TouchEvent) => {
-        setTouchEnd(e.targetTouches[0].clientX);
-    };
-
-    const onTouchEnd = () => {
-        if (!touchStart || !touchEnd) return;
-        
-        const distance = touchStart - touchEnd;
-        const isLeftSwipe = distance > minSwipeDistance;
-        const isRightSwipe = distance < -minSwipeDistance;
-
-        if (isLeftSwipe) {
-            nextImage();
-        } else if (isRightSwipe) {
-            prevImage();
-        }
-    };
-
     const isVideo = (url: string) => {
         const videoExtensions = ['.mp4', '.webm', '.ogg', '.mov'];
         return videoExtensions.some(ext => url.toLowerCase().endsWith(ext));
     };
 
-    // 表示するドットの範囲を計算（最大5個）
     const getVisibleDotIndices = () => {
         const maxVisible = 5;
         if (headerImages.length <= maxVisible) return headerImages.map((_, i) => i);
-        
         let start = Math.max(0, activeDotIndex - 2);
         if (start + maxVisible > headerImages.length) {
             start = headerImages.length - maxVisible;
@@ -103,44 +158,33 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
 
     const visibleDotIndices = getVisibleDotIndices();
 
-    if (headerImages.length === 0) {
-        return null;
-    }
+    if (headerImages.length === 0) return null;
 
     return(
         <div className={styles.header}>
             <div 
+                ref={containerRef}
                 className={styles.galleryContainer}
                 onTouchStart={onTouchStart}
                 onTouchMove={onTouchMove}
                 onTouchEnd={onTouchEnd}
             >
                 <div 
+                    ref={trackRef}
                     className={styles.imageTrack} 
-                    style={{ 
-                        transform: `translateX(-${currentImgIndex * 100}%)`,
-                        transition: isTransitioning ? 'transform 0.5s ease-in-out' : 'none'
-                    }}
                     onTransitionEnd={handleTransitionEnd}
                 >
                 {extendedImages.map((src, index) => (
                     <div key={index} className={styles.imageContainer}>
                     {isVideo(src) ? (
-                        <video 
-                            src={src} 
-                            className={styles.mainVideo} 
-                            autoPlay 
-                            muted 
-                            loop 
-                            playsInline 
-                        />
+                        <video src={src} className={styles.mainVideo} autoPlay muted loop playsInline />
                     ) : (
                         <Image
                             src={src}
                             alt={`Spot Media ${index}`}
                             fill
                             className={styles.mainImage}
-                            priority={index === 1} // 本物の最初の画像にpriorityをつける
+                            priority={index === 1}
                             unoptimized={src.startsWith('http')}
                         />
                     )}
@@ -150,14 +194,10 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
                 {headerImages.length > 1 && (
                 <>
                     <div className={styles.carouselNav}>
-                    <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} aria-label="前の画像へ" />
-                    <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} aria-label="次の画像へ" />
+                        <ChevronLeft size={32} onClick={prevImage} className={styles.navIcon} aria-label="前の画像へ" />
+                        <ChevronRight size={32} onClick={nextImage} className={styles.navIcon} aria-label="次の画像へ" />
                     </div>
-                    <div 
-                        className={styles.carouselIndicator} 
-                        role="group" 
-                        aria-label="画像スライダーの進捗"
-                    >
+                    <div className={styles.carouselIndicator} role="group" aria-label="画像スライダーの進捗">
                     {visibleDotIndices.map((index, idx) => {
                         const isActive = index === activeDotIndex;
                         const isFirst = idx === 0;
@@ -184,3 +224,4 @@ export default function PhotoGallery ({ images = [] }: PhotoGalleryProps) {
         </div>
     )
 }
+


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
PhotoGalleryを指に追従するようにしました。

## 変更内容
- bodyの横揺れ防止および、モバイルブラウザでの意図しない「戻る・進む」ジェスチャーを防止
- スライダーのドラッグ追従に useRef と requestAnimationFrame を導入し、描画負荷を軽減
- 画面サイズ変更時にスライダー幅を動的に再計算する処理を追加

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 