### PR TITLE
Feat: LIFFのstateパラメータに基づいたリダイレクト処理を追加

### DIFF
--- a/miniApp/frontend/app/page.tsx
+++ b/miniApp/frontend/app/page.tsx
@@ -6,6 +6,13 @@ type Props = {
 
 export default async function Home({ searchParams }: Props) {
   const params = await searchParams;
+
+  // LIFF経由のアクセス: liff.state に元のパスが入っているのでそちらへリダイレクト
+  const liffState = params["liff.state"];
+  if (typeof liffState === "string" && liffState.startsWith("/")) {
+    redirect(liffState);
+  }
+
   const queryString = new URLSearchParams();
 
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
LIFFのstateパラメータに基づいたリダイレクト処理を追加

## 変更内容
- liff.stateパラメータに遷移先のパスが含まれている場合に、そのパスへリダイレクトする処理を実装しました。これにより、LIFFブラウザでのアクセス時に適切なページへ遷移できるようになります。

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 